### PR TITLE
WIP Update Bevy to main

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,28 +15,28 @@ extension_anchor_indicator = ["bevy_gizmos"]
 extension_independent_skybox = ["bevy_asset", "bevy_core_pipeline"]
 
 [dependencies]
-bevy_app = "0.14"
-bevy_color = "0.14"
-bevy_derive = "0.14"
-bevy_ecs = "0.14"
-bevy_input = "0.14"
-bevy_log = "0.14"
-bevy_math = "0.14"
-bevy_reflect = "0.14"
-bevy_render = "0.14"
-bevy_time = "0.14"
-bevy_transform = "0.14"
-bevy_utils = "0.14"
-bevy_window = "0.14"
+bevy_app = "0.15.0-dev"
+bevy_color = "0.15.0-dev"
+bevy_derive = "0.15.0-dev"
+bevy_ecs = "0.15.0-dev"
+bevy_input = "0.15.0-dev"
+bevy_log = "0.15.0-dev"
+bevy_math = "0.15.0-dev"
+bevy_reflect = "0.15.0-dev"
+bevy_render = "0.15.0-dev"
+bevy_time = "0.15.0-dev"
+bevy_transform = "0.15.0-dev"
+bevy_utils = "0.15.0-dev"
+bevy_window = "0.15.0-dev"
 # Optional
-bevy_asset = { version = "0.14", optional = true }
-bevy_core_pipeline = { version = "0.14", optional = true }
-bevy_gizmos = { version = "0.14", optional = true }
+bevy_asset = { version = "0.15.0-dev", optional = true }
+bevy_core_pipeline = { version = "0.15.0-dev", optional = true }
+bevy_gizmos = { version = "0.15.0-dev", optional = true }
 # 3rd party
 bevy_picking_core = "0.20.0"
 
 [dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0", default-features = false, features = [
+bevy = { version = "0.15.0-dev", default-features = false, features = [
     "bevy_gizmos",
     "bevy_gltf",
     "bevy_scene",
@@ -52,31 +52,34 @@ bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0", defaul
     "zstd",
 ] }
 bevy_mod_picking = { version = "0.20.0", default-features = false, features = [
-    "backend_raycast",
+    # "backend_raycast",
 ] }
 # big_space = "0.7.0"
 rand = "0.8"
 
 [patch.crates-io]
-bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
-bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
-bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
-bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
-bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
-bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
-bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
-bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
-bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
-bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
-bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
-bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
-bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+bevy_app = { path = "../bevy/crates/bevy_app" }
+bevy_color = { path = "../bevy/crates/bevy_color" }
+bevy_derive = { path = "../bevy/crates/bevy_derive" }
+bevy_ecs = { path = "../bevy/crates/bevy_ecs" }
+bevy_input = { path = "../bevy/crates/bevy_input" }
+bevy_log = { path = "../bevy/crates/bevy_log" }
+bevy_math = { path = "../bevy/crates/bevy_math" }
+bevy_reflect = { path = "../bevy/crates/bevy_reflect" }
+bevy_render = { path = "../bevy/crates/bevy_render" }
+bevy_time = { path = "../bevy/crates/bevy_time" }
+bevy_transform = { path = "../bevy/crates/bevy_transform" }
+bevy_utils = { path = "../bevy/crates/bevy_utils" }
+bevy_window = { path = "../bevy/crates/bevy_window" }
 # Optional
-bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
-bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
-bevy_gizmos = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+bevy_asset = { path = "../bevy/crates/bevy_asset" }
+bevy_core_pipeline = { path = "../bevy/crates/bevy_core_pipeline" }
+bevy_gizmos = { path = "../bevy/crates/bevy_gizmos" }
 # Dev
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+bevy = { path = "../bevy" }
 # Upstream update needed
-bevy_picking_core = { path = "../bevy_mod_picking" }
+bevy_picking_core = { path = "../bevy_mod_picking/crates/bevy_picking_core" }
 bevy_mod_picking = { path = "../bevy_mod_picking" }
+# transitive dependencies
+bevy_hierarchy = { path = "../bevy/crates/bevy_hierarchy" }
+bevy_core = { path = "../bevy/crates/bevy_core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,28 +15,28 @@ extension_anchor_indicator = ["bevy_gizmos"]
 extension_independent_skybox = ["bevy_asset", "bevy_core_pipeline"]
 
 [dependencies]
-bevy_app = "0.14.0"
-bevy_color = "0.14.0"
-bevy_derive = "0.14.0"
-bevy_ecs = "0.14.0"
-bevy_input = "0.14.0"
-bevy_log = "0.14.0"
-bevy_math = "0.14.0"
-bevy_reflect = "0.14.0"
-bevy_render = "0.14.0"
-bevy_time = "0.14.0"
-bevy_transform = "0.14.0"
-bevy_utils = "0.14.0"
-bevy_window = "0.14.0"
+bevy_app = "0.14"
+bevy_color = "0.14"
+bevy_derive = "0.14"
+bevy_ecs = "0.14"
+bevy_input = "0.14"
+bevy_log = "0.14"
+bevy_math = "0.14"
+bevy_reflect = "0.14"
+bevy_render = "0.14"
+bevy_time = "0.14"
+bevy_transform = "0.14"
+bevy_utils = "0.14"
+bevy_window = "0.14"
 # Optional
-bevy_asset = { version = "0.14.0", optional = true }
-bevy_core_pipeline = { version = "0.14.0", optional = true }
-bevy_gizmos = { version = "0.14.0", optional = true }
+bevy_asset = { version = "0.14", optional = true }
+bevy_core_pipeline = { version = "0.14", optional = true }
+bevy_gizmos = { version = "0.14", optional = true }
 # 3rd party
 bevy_picking_core = "0.20.0"
 
 [dev-dependencies]
-bevy = { version = "0.14.0", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0", default-features = false, features = [
     "bevy_gizmos",
     "bevy_gltf",
     "bevy_scene",
@@ -54,6 +54,29 @@ bevy = { version = "0.14.0", default-features = false, features = [
 bevy_mod_picking = { version = "0.20.0", default-features = false, features = [
     "backend_raycast",
 ] }
-
-big_space = "0.7.0"
+# big_space = "0.7.0"
 rand = "0.8"
+
+[patch.crates-io]
+bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+# Optional
+bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+bevy_gizmos = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+# Dev
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0" }
+# Upstream update needed
+bevy_picking_core = { path = "../bevy_mod_picking" }
+bevy_mod_picking = { path = "../bevy_mod_picking" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,28 +58,29 @@ bevy_mod_picking = { version = "0.20.0", default-features = false, features = [
 rand = "0.8"
 
 [patch.crates-io]
-bevy_app = { path = "../bevy/crates/bevy_app" }
-bevy_color = { path = "../bevy/crates/bevy_color" }
-bevy_derive = { path = "../bevy/crates/bevy_derive" }
-bevy_ecs = { path = "../bevy/crates/bevy_ecs" }
-bevy_input = { path = "../bevy/crates/bevy_input" }
-bevy_log = { path = "../bevy/crates/bevy_log" }
-bevy_math = { path = "../bevy/crates/bevy_math" }
-bevy_reflect = { path = "../bevy/crates/bevy_reflect" }
-bevy_render = { path = "../bevy/crates/bevy_render" }
-bevy_time = { path = "../bevy/crates/bevy_time" }
-bevy_transform = { path = "../bevy/crates/bevy_transform" }
-bevy_utils = { path = "../bevy/crates/bevy_utils" }
-bevy_window = { path = "../bevy/crates/bevy_window" }
+bevy_app = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
+bevy_color = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
+bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
+bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
+bevy_input = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
+bevy_log = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
+bevy_math = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
+bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
+bevy_render = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
+bevy_time = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
+bevy_transform = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
+bevy_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
+bevy_window = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
 # Optional
-bevy_asset = { path = "../bevy/crates/bevy_asset" }
-bevy_core_pipeline = { path = "../bevy/crates/bevy_core_pipeline" }
-bevy_gizmos = { path = "../bevy/crates/bevy_gizmos" }
+bevy_asset = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
+bevy_core_pipeline = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
+bevy_gizmos = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
 # Dev
-bevy = { path = "../bevy" }
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
 # Upstream update needed
-bevy_picking_core = { path = "../bevy_mod_picking/crates/bevy_picking_core" }
-bevy_mod_picking = { path = "../bevy_mod_picking" }
+bevy_picking_core = { git = "https://github.com/vrixyz/bevy_mod_picking.git", branch = "bevy_main" }
+bevy_mod_picking = { git = "https://github.com/vrixyz/bevy_mod_picking.git", branch = "bevy_main" }
 # transitive dependencies
-bevy_hierarchy = { path = "../bevy/crates/bevy_hierarchy" }
-bevy_core = { path = "../bevy/crates/bevy_core" }
+bevy_hierarchy = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
+bevy_core = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d159" }
+bevy_eventlistener = { git = "https://github.com/vrixyz/bevy_eventlistener.git", branch = "bevy_main" }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -23,6 +23,7 @@ fn setup_camera(mut commands: Commands, asset_server: Res<AssetServer>) {
             intensity: 1000.0,
             diffuse_map: asset_server.load("environment_maps/diffuse_rgb9e5_zstd.ktx2"),
             specular_map: asset_server.load("environment_maps/specular_rgb9e5_zstd.ktx2"),
+            ..Default::default()
         },
     ));
 }

--- a/examples/ortho.rs
+++ b/examples/ortho.rs
@@ -20,8 +20,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Camera3dBundle {
             transform: Transform::from_xyz(10.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
             projection: Projection::Orthographic(OrthographicProjection {
-                scale: 0.01,
-                ..default()
+                ..OrthographicProjection::default_3d()
             }),
             ..default()
         },
@@ -29,6 +28,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             intensity: 1000.0,
             diffuse_map: diffuse_map.clone(),
             specular_map: specular_map.clone(),
+            ..Default::default()
         },
         // This component makes the camera controllable with this plugin.
         //

--- a/examples/pseudo_ortho.rs
+++ b/examples/pseudo_ortho.rs
@@ -36,6 +36,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             intensity: 1000.0,
             diffuse_map: diffuse_map.clone(),
             specular_map: specular_map.clone(),
+            ..Default::default()
         },
         // This component makes the camera controllable with this plugin:
         EditorCam::default(),

--- a/examples/split_screen.rs
+++ b/examples/split_screen.rs
@@ -63,6 +63,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 ..default()
             },
             projection: Projection::Orthographic(OrthographicProjection {
+                scaling_mode: ScalingMode::WindowSize(100.0),
                 ..OrthographicProjection::default_3d()
             }),
             tonemapping: Tonemapping::AcesFitted,

--- a/examples/split_screen.rs
+++ b/examples/split_screen.rs
@@ -40,6 +40,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             intensity: 1000.0,
             diffuse_map: diffuse_map.clone(),
             specular_map: specular_map.clone(),
+            ..Default::default()
         },
         EditorCam::default(),
         bevy_editor_cam::extensions::independent_skybox::IndependentSkybox::new(
@@ -62,8 +63,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 ..default()
             },
             projection: Projection::Orthographic(OrthographicProjection {
-                scale: 0.01,
-                ..default()
+                ..OrthographicProjection::default_3d()
             }),
             tonemapping: Tonemapping::AcesFitted,
             ..default()
@@ -72,6 +72,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             intensity: 1000.0,
             diffuse_map: diffuse_map.clone(),
             specular_map: specular_map.clone(),
+            ..Default::default()
         },
         EditorCam::default(),
         bevy_editor_cam::extensions::independent_skybox::IndependentSkybox::new(diffuse_map, 500.0),

--- a/src/controller/component.rs
+++ b/src/controller/component.rs
@@ -385,7 +385,10 @@ impl EditorCam {
                 };
                 offset
             }
-            Projection::Orthographic(ortho) => DVec2::new(-ortho.scale as f64, ortho.scale as f64),
+            Projection::Orthographic(ortho) => DVec2::new(
+                -ortho.area.width() as f64 / 2.0,
+                ortho.area.height() as f64 / 2.0,
+            ),
         };
 
         let pan_translation_view_space = (pan * view_offset).extend(0.0);
@@ -396,7 +399,7 @@ impl EditorCam {
         let zoom_translation_view_space = match projection {
             Projection::Perspective(_) => anchor.normalize() * scaled_zoom * anchor.z * -0.15,
             Projection::Orthographic(ref mut ortho) => {
-                ortho.scale *= 1.0 - scaled_zoom as f32 * 0.15;
+                ortho.scaling_mode *= 1.0 - scaled_zoom as f32 * 0.15;
                 // We don't move the camera in z, as this is managed by another ortho system.
                 anchor.normalize() * scaled_zoom * anchor.z.abs() * 0.15 * DVec3::new(1.0, 1.0, 0.0)
             }

--- a/src/controller/projections.rs
+++ b/src/controller/projections.rs
@@ -90,7 +90,9 @@ pub fn update_orthographic(mut cameras: Query<(&mut EditorCam, &mut Projection, 
         };
 
         let anchor_dist = editor_cam.last_anchor_depth().abs() as f32;
-        let target_dist = (editor_cam.orthographic.scale_to_near_clip * orthographic.scale).clamp(
+        let target_dist = (editor_cam.orthographic.scale_to_near_clip
+            * (orthographic.area.width() * orthographic.area.height()))
+        .clamp(
             editor_cam.orthographic.near_clip_limits.start,
             editor_cam.orthographic.near_clip_limits.end,
         );

--- a/src/extensions/anchor_indicator.rs
+++ b/src/extensions/anchor_indicator.rs
@@ -80,8 +80,7 @@ pub fn draw_anchor(
             let arm_length = 0.4;
 
             gizmos.circle(
-                anchor_world,
-                Dir3::new_unchecked(cam_transform.forward().normalize()),
+                Isometry3d::from_translation(anchor_world),
                 scale,
                 gizmo_color(),
             );

--- a/src/extensions/dolly_zoom.rs
+++ b/src/extensions/dolly_zoom.rs
@@ -81,7 +81,8 @@ impl DollyZoomTrigger {
                         continue;
                     }
 
-                    let base = ortho.scale as f64 / ortho_tri_base_to_scale_factor(camera, ortho);
+                    let base = (ortho.area.width() * ortho.area.height()) as f64
+                        / ortho_tri_base_to_scale_factor(camera, ortho);
                     let new_anchor_dist = base / (ZERO_FOV / 2.0).tan();
                     let forward_dist = controller.last_anchor_depth.abs() - new_anchor_dist;
                     let next_translation = transform.forward().as_dvec3() * forward_dist;
@@ -222,8 +223,8 @@ impl DollyZoom {
                 *projection = proj_end.clone();
                 if let Projection::Orthographic(ortho) = &mut *projection {
                     let multiplier = ortho_tri_base_to_scale_factor(camera, ortho);
-
-                    ortho.scale = (*triangle_base * multiplier) as f32;
+                    let normalized_projection = ortho.scaling_mode / multiplier as f32;
+                    ortho.scaling_mode = normalized_projection * *triangle_base as f32;
                 }
                 controller.enabled_motion = initial_enabled.clone();
                 *complete = true;

--- a/src/extensions/independent_skybox.rs
+++ b/src/extensions/independent_skybox.rs
@@ -138,6 +138,7 @@ impl IndependentSkyboxCamera {
                     Skybox {
                         image: editor_without_skybox.skybox.clone(),
                         brightness: editor_without_skybox.brightness,
+                        ..Default::default()
                     },
                     IndependentSkyboxCamera {
                         driven_by: editor_cam_entity,


### PR DESCRIPTION
Currently testing on [bevy commit 9386bd0](https://github.com/bevyengine/bevy/commit/9386bd0114c44c9f00a2e9c41db1225aaa78d159)

- TODO: update to proper 0.15 and keep a lookout for https://github.com/bevyengine/bevy/pull/15969.



⚠️ big_space hasn't been updated.

Notable changes from bevy:
- orthographic scale has been removed: https://github.com/bevyengine/bevy/pull/15075
  - ⚠️ This is a difficult change to adapt to, the orthographic projection is broken (zooms too much?).
- orthographic projection default has 2 versions: 2d and 3d: https://github.com/bevyengine/bevy/pull/15073
- Msaa is now a component: https://github.com/bevyengine/bevy/pull/14273