### PR TITLE
Zoom Bugfixes

### DIFF
--- a/src/controller/component.rs
+++ b/src/controller/component.rs
@@ -51,8 +51,7 @@ pub struct EditorCam {
     pub enabled_motion: EnabledMotion,
     /// The type of camera orbit to use.
     pub orbit_constraint: OrbitConstraint,
-    /// How close can the camera get to object before zooming through it. None
-    /// disables zooming through objects.
+    /// Set near and far zoom limits, as well as the ability to zoom through objects.
     pub zoom_limits: ZoomLimits,
     /// Input smoothing of camera motion.
     pub smoothing: Smoothing,
@@ -397,8 +396,7 @@ impl EditorCam {
         let pan_translation_view_space = (pan * view_offset).extend(0.0);
 
         let size_at_anchor =
-            super::zoom::length_per_pixel_at_view_space_pos(camera, anchor.as_vec3())
-                .unwrap_or(0.0);
+            super::zoom::length_per_pixel_at_view_space_pos(camera, *anchor).unwrap_or(0.0);
 
         // I'm not sure why I created this mapping - maybe it was to prevent zooming through
         // surfaces if the user really whipped the mouse:
@@ -557,8 +555,8 @@ impl EditorCam {
     ///
     /// This function correctly accounts for camera projection, and is particularly useful when
     /// doing zoom and scale calculations.
-    pub fn length_per_pixel_at_anchor(&self, camera: &Camera) -> Option<f32> {
-        let anchor_view = self.anchor_view_space()?.as_vec3();
+    pub fn length_per_pixel_at_anchor(&self, camera: &Camera) -> Option<f64> {
+        let anchor_view = self.anchor_view_space()?;
         super::zoom::length_per_pixel_at_view_space_pos(camera, anchor_view)
     }
 

--- a/src/controller/zoom.rs
+++ b/src/controller/zoom.rs
@@ -1,8 +1,6 @@
 //! Provides [`ZoomLimits`] settings.
 
-use core::f32;
-
-use bevy_math::prelude::*;
+use bevy_math::{DVec2, DVec3};
 use bevy_reflect::Reflect;
 use bevy_render::prelude::*;
 
@@ -18,7 +16,7 @@ pub struct ZoomLimits {
     ///
     /// Setting this to a small value will let you zoom in further. If this is too small, you may
     /// begin to encounter floating point rendering errors.
-    pub min_size_per_pixel: f32,
+    pub min_size_per_pixel: f64,
     /// The largest size in world space units of a pixel located at the anchor when zooming out.
     ///
     /// When zooming out, a single pixel will cover a larger and larger world space area. This limit
@@ -27,7 +25,7 @@ pub struct ZoomLimits {
     /// anchor  was the size of a pixel.
     ///
     /// Setting this to a large value will let you zoom out further.
-    pub max_size_per_pixel: f32,
+    pub max_size_per_pixel: f64,
     /// When true, and when a perspective projection is being used, zooming in can pass through
     /// objects. When reaching `min_size_per_pixel`, instead of stopping, the camera will continue
     /// moving forward, passing through the object in front of the camera.
@@ -40,34 +38,45 @@ pub struct ZoomLimits {
 impl Default for ZoomLimits {
     fn default() -> Self {
         Self {
-            min_size_per_pixel: 1e-7, // Any smaller and floating point rendering artifacts appear.
-            max_size_per_pixel: f32::MAX,
+            min_size_per_pixel: 1e-6, // Any smaller and floating point rendering artifacts appear.
+            max_size_per_pixel: 1e27, // The diameter of the observable universe is probably a good upper limit.
             zoom_through_objects: false,
         }
     }
 }
 
-/// The size of a pixel in world space units, located at the provided view space position.
-pub fn length_per_pixel_at_view_space_pos(camera: &Camera, view_space_pos: Vec3) -> Option<f32> {
-    // A point offset one unit in the x direction in view space, in world scale. This is a point
-    // offset by 1.0 unit to the right relative to the camera facing the anchor point. We can then
-    // project the anchor and the offset anchor onto the viewport (screen), to see how many pixels
-    // apart these two points, one world unit offset apart, are on screen. This gives us the world
-    // units per pixel, at the anchor (pointer) location.
-    let view_space_pos_offset = view_space_pos + Vec3::X;
+/// The size of a pixel at the anchor (under the pointer) in world space units.
+///
+/// This is a much better way to compute scale than using camera distance from the anchor (the
+/// length of the anchor vector). Anchor distance does not take camera projection into account.
+pub fn length_per_pixel_at_view_space_pos(camera: &Camera, view_space_pos: DVec3) -> Option<f64> {
+    // This is a point offset by scaled_offset units to the right relative to the camera facing the
+    // anchor point. We can then project the anchor and the offset anchor onto the viewport
+    // (screen), to see how many pixels apart these two points are on screen. This gives us the
+    // world units per pixel, at the anchor (pointer) location.
+    //
+    // The scaled_offset is important for handling varying scales. If we only offset by a unit value
+    // (1.0), then at large distances, an offset of 1.0 would round to 0.0 when projected on the
+    // screen, and the result, a reciprocal, would go to infinity. To combat this, we ensure that
+    // our offset is a similar scale to the anchor distance itself, and cancel it out later.
+    let scaled_offset = view_space_pos.length();
+    let view_space_pos_offset = view_space_pos + DVec3::X * scaled_offset;
 
-    let viewport_pos = view_to_viewport(view_space_pos, camera)?;
-    let viewport_pos_offset = view_to_viewport(view_space_pos_offset, camera)?;
+    let viewport_pos = view_to_viewport(camera, view_space_pos)?;
+    let viewport_pos_offset = view_to_viewport(camera, view_space_pos_offset)?;
 
     let pixels_per_world_unit = (viewport_pos_offset - viewport_pos).length();
     // The length per pixel is the inverse of pixels_per_world_unit
-    let len_per_pixel = pixels_per_world_unit.recip();
+    let len_per_pixel = pixels_per_world_unit.recip().min(f64::MAX) * scaled_offset;
     len_per_pixel.is_finite().then_some(len_per_pixel)
 }
 
 /// Project a point in view space onto the camera's viewport.
-fn view_to_viewport(view_space_point: Vec3, camera: &Camera) -> Option<Vec2> {
-    let ndc_space_coords = camera.clip_from_view().project_point3(view_space_point);
+fn view_to_viewport(camera: &Camera, view_space_point: DVec3) -> Option<DVec2> {
+    let ndc_space_coords = camera
+        .clip_from_view()
+        .as_dmat4()
+        .project_point3(view_space_point);
 
     // NDC z-values outside of 0 < z < 1 are outside the (implicit) camera frustum and are thus not
     // in viewport-space
@@ -75,10 +84,10 @@ fn view_to_viewport(view_space_point: Vec3, camera: &Camera) -> Option<Vec2> {
         (!ndc_space_coords.is_nan() && ndc_space_coords.z >= 0.0 && ndc_space_coords.z <= 1.0)
             .then_some(ndc_space_coords)?;
 
-    let target_size = camera.logical_viewport_size()?;
+    let target_size = camera.logical_viewport_size()?.as_dvec2();
 
     // Once in NDC space, we can discard the z element and rescale x/y to fit the screen
-    let mut viewport_position = (ndc_space_coords.truncate() + Vec2::ONE) / 2.0 * target_size;
+    let mut viewport_position = (ndc_space_coords.truncate() + DVec2::ONE) / 2.0 * target_size;
     // Flip the Y co-ordinate origin from the bottom to the top.
     viewport_position.y = target_size.y - viewport_position.y;
     Some(viewport_position)

--- a/src/extensions/dolly_zoom.rs
+++ b/src/extensions/dolly_zoom.rs
@@ -28,7 +28,7 @@ impl Plugin for DollyZoomPlugin {
                 DollyZoom::update
                     .before(crate::controller::component::EditorCam::update_camera_positions),
             )
-            .add_systems(PostUpdate, DollyZoomTrigger::receive) // In PostUpdate so we don't miss users sending this in Update. DollyZoom::update will catch the changes next frame.
+            .add_systems(Last, DollyZoomTrigger::receive) // This mutates camera components, so we want to be sure it runs *after* rendering has happened. We place it in Last to ensure that we wake the next frame if needed. If we run this in PostUpdate, this can result in rendering artifacts because this will mutate projections right before rendering.
             .register_type::<DollyZoom>();
     }
 }
@@ -141,7 +141,7 @@ struct ZoomEntry {
 /// Stores settings and state for the dolly zoom plugin.
 #[derive(Resource, Reflect)]
 pub struct DollyZoom {
-    /// THe duration of the dolly zoom transition animation.
+    /// The duration of the dolly zoom transition animation.
     pub animation_duration: Duration,
     /// The cubic curve used to animate the camera during a dolly zoom.
     #[reflect(ignore)]
@@ -153,7 +153,7 @@ pub struct DollyZoom {
 impl Default for DollyZoom {
     fn default() -> Self {
         Self {
-            animation_duration: Duration::from_millis(200),
+            animation_duration: Duration::from_millis(250),
             animation_curve: CubicSegment::new_bezier((0.25, 0.1), (0.25, 1.0)),
             map: Default::default(),
         }


### PR DESCRIPTION
Fixes for handling zoom at very large scales, as well as clipping artifacts during dolly zoom.

After this change, you can now zoom out past the object the size of the observable universe, and the camera controller will be able to handle zoom limits at this scale without "latching" when floating point computations break down.

This also fixes a dolly zoom bug that has been annoying me forever, where the first frame would show an artifact with the meshes being clipped by the near plane. Turns out this was an ordering issue when receiving dolly zoom events.