### PR TITLE
Upgrade to Bevy 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,13 @@ bevy_core_pipeline = { version = "0.15.0", optional = true }
 bevy_gizmos = { version = "0.15.0", optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.15.0", default-features = false, features = [
+big_space = "0.7.0"
+indoc = "2.0.5"
+rand = "0.8"
+
+[dev-dependencies.bevy]
+version = "0.15.0"
+features = [
     "bevy_gizmos",
     "bevy_gltf",
     "bevy_scene",
@@ -50,10 +56,6 @@ bevy = { version = "0.15.0", default-features = false, features = [
     "tonemapping_luts",
     "x11",
     "zstd",
-] }
-bevy_mod_picking = { version = "0.20.0", default-features = false, features = [
-    "backend_raycast",
-] }
-
-big_space = "0.7.0"
-rand = "0.8"
+]
+# TODO: workaround for https://github.com/bevyengine/bevy/issues/16562
+default-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ bevy_core_pipeline = { version = "0.15.0", optional = true }
 bevy_gizmos = { version = "0.15.0", optional = true }
 
 [dev-dependencies]
-big_space = "0.7.0"
+big_space = "0.8.0"
 indoc = "2.0.5"
 rand = "0.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,28 +15,28 @@ extension_anchor_indicator = ["bevy_gizmos"]
 extension_independent_skybox = ["bevy_asset", "bevy_core_pipeline"]
 
 [dependencies]
-bevy_app = "0.14.0"
-bevy_color = "0.14.0"
-bevy_derive = "0.14.0"
-bevy_ecs = "0.14.0"
-bevy_input = "0.14.0"
-bevy_log = "0.14.0"
-bevy_math = "0.14.0"
-bevy_reflect = "0.14.0"
-bevy_render = "0.14.0"
-bevy_time = "0.14.0"
-bevy_transform = "0.14.0"
-bevy_utils = "0.14.0"
-bevy_window = "0.14.0"
+bevy_app = "0.15.0"
+bevy_color = "0.15.0"
+bevy_derive = "0.15.0"
+bevy_ecs = "0.15.0"
+bevy_image = "0.15.0"
+bevy_input = "0.15.0"
+bevy_log = "0.15.0"
+bevy_math = "0.15.0"
+bevy_picking = "0.15.0"
+bevy_reflect = "0.15.0"
+bevy_render = "0.15.0"
+bevy_time = "0.15.0"
+bevy_transform = "0.15.0"
+bevy_utils = "0.15.0"
+bevy_window = "0.15.0"
 # Optional
-bevy_asset = { version = "0.14.0", optional = true }
-bevy_core_pipeline = { version = "0.14.0", optional = true }
-bevy_gizmos = { version = "0.14.0", optional = true }
-# 3rd party
-bevy_picking_core = "0.20.0"
+bevy_asset = { version = "0.15.0", optional = true }
+bevy_core_pipeline = { version = "0.15.0", optional = true }
+bevy_gizmos = { version = "0.15.0", optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.14.0", default-features = false, features = [
+bevy = { version = "0.15.0", default-features = false, features = [
     "bevy_gizmos",
     "bevy_gltf",
     "bevy_scene",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_editor_cam"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "A camera controller for editors and CAD."
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ https://github.com/aevyrie/bevy_editor_cam/assets/2632925/50e342ac-9cb3-4ab5-857
 
 | bevy | bevy_editor_cam  |
 | ---- | ---------------- |
-| 0.14 | 0.3              |
+| 0.15 | 0.5              |
+| 0.14 | 0.3, 0.4         |
 | 0.13 | 0.2              |
 | 0.12 | 0.1              |
+
 </details>

--- a/examples/cad.rs
+++ b/examples/cad.rs
@@ -16,18 +16,18 @@ use bevy_editor_cam::{
     extensions::{dolly_zoom::DollyZoomTrigger, look_to::LookToTrigger},
     prelude::*,
 };
+use indoc::indoc;
 
 fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            bevy_mod_picking::DefaultPickingPlugins,
             DefaultEditorCamPlugins,
+            MeshPickingPlugin,
             TemporalAntiAliasPlugin,
         ))
         // The camera controller works with reactive rendering:
         // .insert_resource(bevy::winit::WinitSettings::desktop_app())
-        .insert_resource(Msaa::Off)
         .insert_resource(ClearColor(Color::srgb(0.15, 0.15, 0.15)))
         .insert_resource(AmbientLight {
             brightness: 0.0,
@@ -53,7 +53,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let specular_map = asset_server.load("environment_maps/specular_rgb9e5_zstd.ktx2");
 
     commands.spawn(SceneBundle {
-        scene: asset_server.load("models/PlaneEngine/scene.gltf#Scene0"),
+        scene: SceneRoot(asset_server.load("models/PlaneEngine/scene.gltf#Scene0")),
         transform: Transform::from_scale(Vec3::splat(2.0)),
         ..Default::default()
     });
@@ -62,16 +62,15 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     let camera = commands
         .spawn((
-            Camera3dBundle {
-                transform: cam_trans,
-                tonemapping: Tonemapping::AcesFitted,
-                ..default()
-            },
+            Camera3d::default(),
+            cam_trans,
+            Tonemapping::AcesFitted,
             BloomSettings::default(),
             EnvironmentMapLight {
                 intensity: 1000.0,
                 diffuse_map: diffuse_map.clone(),
                 specular_map: specular_map.clone(),
+                rotation: default(),
             },
             EditorCam {
                 orbit_constraint: OrbitConstraint::Free,
@@ -86,10 +85,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
 fn projection_specific_render_config(
     mut commands: Commands,
-    cam: Query<(Entity, &Projection), With<EditorCam>>,
-    mut msaa: ResMut<Msaa>,
+    mut cam: Query<(Entity, &Projection, &mut Msaa), With<EditorCam>>,
 ) {
-    let (entity, proj) = cam.single();
+    let (entity, proj, mut msaa) = cam.single_mut();
     match proj {
         Projection::Perspective(_) => {
             *msaa = Msaa::Off;
@@ -117,7 +115,7 @@ fn toggle_projection(
     if keys.just_pressed(KeyCode::KeyP) {
         *toggled = !*toggled;
         let target_projection = if *toggled {
-            Projection::Orthographic(OrthographicProjection::default())
+            Projection::Orthographic(OrthographicProjection::default_3d())
         } else {
             Projection::Perspective(PerspectiveProjection::default())
         };
@@ -211,37 +209,23 @@ fn switch_direction(
 }
 
 fn setup_ui(mut commands: Commands, camera: Entity) {
-    let style = TextStyle {
-        font_size: 20.0,
-        ..default()
-    };
-    commands
-        .spawn((
-            TargetCamera(camera),
-            NodeBundle {
-                style: Style {
-                    width: Val::Percent(100.),
-                    height: Val::Percent(100.),
-                    padding: UiRect::all(Val::Px(20.)),
-                    ..default()
-                },
-                ..default()
-            },
-        ))
-        .with_children(|parent| {
-            parent.spawn(
-                TextBundle::from_sections(vec![
-                    TextSection::new("Left Mouse - Pan\n", style.clone()),
-                    TextSection::new("Right Mouse - Orbit\n", style.clone()),
-                    TextSection::new("Scroll - Zoom\n", style.clone()),
-                    TextSection::new("P - Toggle projection\n", style.clone()),
-                    TextSection::new("C - Toggle orbit constraint\n", style.clone()),
-                    TextSection::new("E - Toggle explode\n", style.clone()),
-                    TextSection::new("1-6 - Switch direction\n", style.clone()),
-                ])
-                .with_style(Style { ..default() }),
-            );
-        });
+    let text = indoc! {"
+        Left Mouse  - Pan
+        Right Mouse - Orbit
+        Scroll      - Zoom
+        P           - Toggle projection
+        C           - Toggle orbit constraint
+        E           - Toggle explode
+        1-6         - Switch direction
+    "};
+    commands.spawn((
+        Text::new(text),
+        TextFont {
+            font_size: 20.0,
+            ..default()
+        },
+        TargetCamera(camera),
+    ));
 }
 
 #[derive(Component)]
@@ -254,7 +238,7 @@ fn explode(
     mut toggle: Local<Option<(bool, Instant, f32)>>,
     mut explode_amount: Local<f32>,
     mut redraw: EventWriter<RequestRedraw>,
-    mut parts: Query<(Entity, &mut Transform, &Aabb, Option<&StartPos>), With<Handle<Mesh>>>,
+    mut parts: Query<(Entity, &mut Transform, &Aabb, Option<&StartPos>), With<Mesh3d>>,
     mut matls: ResMut<Assets<StandardMaterial>>,
 ) {
     let animation = Duration::from_millis(2000);

--- a/examples/cad.rs
+++ b/examples/cad.rs
@@ -2,16 +2,15 @@ use std::time::Duration;
 
 use bevy::{
     core_pipeline::{
-        bloom::BloomSettings,
-        experimental::taa::{TemporalAntiAliasBundle, TemporalAntiAliasPlugin},
-        tonemapping::Tonemapping,
+        bloom::Bloom, experimental::taa::TemporalAntiAliasPlugin, tonemapping::Tonemapping,
     },
-    pbr::ScreenSpaceAmbientOcclusionBundle,
+    pbr::ScreenSpaceAmbientOcclusion,
     prelude::*,
     render::{camera::TemporalJitter, primitives::Aabb},
     utils::Instant,
     window::RequestRedraw,
 };
+use bevy_core_pipeline::experimental::taa::TemporalAntiAliasing;
 use bevy_editor_cam::{
     extensions::{dolly_zoom::DollyZoomTrigger, look_to::LookToTrigger},
     prelude::*,
@@ -52,11 +51,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let diffuse_map = asset_server.load("environment_maps/diffuse_rgb9e5_zstd.ktx2");
     let specular_map = asset_server.load("environment_maps/specular_rgb9e5_zstd.ktx2");
 
-    commands.spawn(SceneBundle {
-        scene: SceneRoot(asset_server.load("models/PlaneEngine/scene.gltf#Scene0")),
-        transform: Transform::from_scale(Vec3::splat(2.0)),
-        ..Default::default()
-    });
+    commands.spawn((
+        SceneRoot(asset_server.load("models/PlaneEngine/scene.gltf#Scene0")),
+        Transform::from_scale(Vec3::splat(2.0)),
+    ));
 
     let cam_trans = Transform::from_xyz(2.0, 2.0, 2.0).looking_at(Vec3::ZERO, Vec3::Y);
 
@@ -65,7 +63,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             Camera3d::default(),
             cam_trans,
             Tonemapping::AcesFitted,
-            BloomSettings::default(),
+            Bloom::default(),
             EnvironmentMapLight {
                 intensity: 1000.0,
                 diffuse_map: diffuse_map.clone(),
@@ -93,15 +91,15 @@ fn projection_specific_render_config(
             *msaa = Msaa::Off;
             commands
                 .entity(entity)
-                .insert(TemporalAntiAliasBundle::default())
-                .insert(ScreenSpaceAmbientOcclusionBundle::default());
+                .insert(TemporalAntiAliasing::default())
+                .insert(ScreenSpaceAmbientOcclusion::default());
         }
         Projection::Orthographic(_) => {
             *msaa = Msaa::Sample4;
             commands
                 .entity(entity)
                 .remove::<TemporalJitter>()
-                .remove::<ScreenSpaceAmbientOcclusionBundle>();
+                .remove::<ScreenSpaceAmbientOcclusion>();
         }
     }
 }

--- a/examples/floating_origin.rs
+++ b/examples/floating_origin.rs
@@ -38,15 +38,12 @@ fn setup(
 ) {
     commands.spawn_big_space(ReferenceFrame::<i128>::default(), |root| {
         root.spawn_spatial((
-            Camera3dBundle {
-                transform: Transform::from_xyz(0.0, 0.0, 8.0)
-                    .looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
-                projection: Projection::Perspective(PerspectiveProjection {
-                    near: 1e-18,
-                    ..default()
-                }),
+            Camera3d::default(),
+            Transform::from_xyz(0.0, 0.0, 8.0).looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
+            Projection::Perspective(PerspectiveProjection {
+                near: 1e-18,
                 ..default()
-            },
+            }),
             FloatingOrigin, // Important: marks the floating origin entity for rendering.
             EditorCam {
                 zoom_limits: ZoomLimits {

--- a/examples/floating_origin.rs
+++ b/examples/floating_origin.rs
@@ -4,22 +4,23 @@ use bevy_editor_cam::{
     prelude::{projections::PerspectiveSettings, zoom::ZoomLimits},
     DefaultEditorCamPlugins,
 };
-use bevy_mod_picking::DefaultPickingPlugins;
 use big_space::{
     commands::BigSpaceCommands,
     reference_frame::{local_origin::ReferenceFrames, ReferenceFrame},
-    world_query::GridTransformReadOnly,
-    FloatingOrigin,
+    world_query::{GridTransformReadOnly, GridTransformReadOnlyItem},
+    FloatingOrigin, GridCell,
 };
+use indoc::formatdoc;
 
 fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins.build().disable::<TransformPlugin>(),
+            MeshPickingPlugin,
             big_space::BigSpacePlugin::<i128>::default(),
             big_space::debug::FloatingOriginDebugPlugin::<i128>::default(),
         ))
-        .add_plugins((DefaultEditorCamPlugins, DefaultPickingPlugins))
+        .add_plugins(DefaultEditorCamPlugins)
         .insert_resource(ClearColor(Color::BLACK))
         .insert_resource(AmbientLight {
             color: Color::WHITE,
@@ -75,20 +76,16 @@ fn setup(
             translation.x += j / 2.0 + k;
             translation.y = j / 2.0;
 
-            root.spawn_spatial(PbrBundle {
-                mesh: mesh_handle.clone(),
-                material: matl_handle.clone(),
-                transform: Transform::from_scale(Vec3::splat(j)).with_translation(translation),
-                ..default()
-            });
+            root.spawn_spatial((
+                Mesh3d(mesh_handle.clone()),
+                MeshMaterial3d(matl_handle.clone()),
+                Transform::from_scale(Vec3::splat(j)).with_translation(translation),
+            ));
         }
 
         // light
-        root.spawn_spatial(DirectionalLightBundle {
-            directional_light: DirectionalLight {
-                illuminance: 10_000.0,
-                ..default()
-            },
+        root.spawn_spatial(DirectionalLight {
+            illuminance: 10_000.0,
             ..default()
         });
     });
@@ -102,41 +99,21 @@ pub struct FunFactText;
 
 fn ui_setup(mut commands: Commands) {
     commands.spawn((
-        TextBundle::from_section(
-            "",
-            TextStyle {
-                font_size: 18.0,
-                color: Color::WHITE,
-                ..default()
-            },
-        )
-        .with_text_justify(JustifyText::Left)
-        .with_style(Style {
-            position_type: PositionType::Absolute,
-            top: Val::Px(10.0),
-            left: Val::Px(10.0),
+        Text::new(""),
+        TextFont {
+            font_size: 18.0,
             ..default()
-        }),
+        },
+        TextColor(Color::WHITE),
         BigSpaceDebugText,
     ));
-
     commands.spawn((
-        TextBundle::from_section(
-            "",
-            TextStyle {
-                font_size: 52.0,
-                color: Color::WHITE,
-                ..default()
-            },
-        )
-        .with_style(Style {
-            position_type: PositionType::Absolute,
-            bottom: Val::Px(10.0),
-            right: Val::Px(10.0),
-            left: Val::Px(10.0),
+        Text::new(""),
+        TextFont {
+            font_size: 52.0,
             ..default()
-        })
-        .with_text_justify(JustifyText::Center),
+        },
+        TextColor(Color::WHITE),
         FunFactText,
     ));
 }
@@ -151,35 +128,33 @@ fn ui_text_system(
     origin: Query<(Entity, GridTransformReadOnly<i128>), With<FloatingOrigin>>,
 ) {
     let (origin_entity, origin_pos) = origin.single();
-    let translation = origin_pos.transform.translation;
-
-    let grid_text = format!(
-        "GridCell: {}x, {}y, {}z",
-        origin_pos.cell.x, origin_pos.cell.y, origin_pos.cell.z
-    );
-
-    let translation_text = format!(
-        "Transform: {}x, {}y, {}z",
-        translation.x, translation.y, translation.z
-    );
-
     let Some(ref_frame) = ref_frames.parent_frame(origin_entity) else {
         return;
     };
 
-    let real_position = ref_frame.grid_position_double(origin_pos.cell, origin_pos.transform);
-    let real_position_f64_text = format!(
-        "Combined (f64): {}x, {}y, {}z",
-        real_position.x, real_position.y, real_position.z
-    );
-    let real_position_f32_text = format!(
-        "Combined (f32): {}x, {}y, {}z",
-        real_position.x as f32, real_position.y as f32, real_position.z as f32
-    );
-
     let mut debug_text = debug_text.single_mut();
+    *debug_text.0 = Text::new(ui_text(ref_frame, &origin_pos));
+}
 
-    debug_text.0.sections[0].value = format!(
-        "{grid_text}\n{translation_text}\n\n{real_position_f64_text}\n{real_position_f32_text}"
-    );
+fn ui_text(
+    ref_frame: &ReferenceFrame<i128>,
+    origin_pos: &GridTransformReadOnlyItem<i128>,
+) -> String {
+    let GridCell {
+        x: cx,
+        y: cy,
+        z: cz,
+    } = origin_pos.cell;
+    let [tx, ty, tz] = origin_pos.transform.translation.into();
+    let [dx, dy, dz] = ref_frame
+        .grid_position_double(origin_pos.cell, origin_pos.transform)
+        .into();
+    let [sx, sy, sz] = [dx as f32, dy as f32, dz as f32];
+
+    formatdoc! {"
+        GridCell: {cx}x, {cy}y, {cz}z
+        Transform: {tx}x, {ty}y, {tz}z
+        Combined (f64): {dx}x, {dy}y, {dz}z
+        Combined (f32): {sx}x, {sy}y, {sz}z
+    "}
 }

--- a/examples/map.rs
+++ b/examples/map.rs
@@ -58,7 +58,7 @@ fn setup(
             ),
         ))
         .insert(ScreenSpaceAmbientOcclusion::default())
-        .insert(TemporalAntiAliasing::default());
+        .insert((Msaa::Off, TemporalAntiAliasing::default()));
 }
 
 fn spawn_buildings(
@@ -144,6 +144,7 @@ fn projection_specific_render_config(
             commands
                 .entity(entity)
                 .remove::<TemporalJitter>()
+                .remove::<TemporalAntiAliasing>()
                 .remove::<ScreenSpaceAmbientOcclusion>();
         }
     }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -17,7 +17,7 @@ fn main() {
 
 fn setup_camera(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
-        Camera3dBundle::default(),
+        Camera3d::default(),
         EditorCam::default(), // Step 2: add camera controller component to any cameras
         EnvironmentMapLight {
             // Unrelated to camera controller, needed for lighting:
@@ -34,11 +34,10 @@ fn setup_camera(mut commands: Commands, asset_server: Res<AssetServer>) {
 //
 
 fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(SceneBundle {
-        scene: SceneRoot(asset_server.load("models/PlaneEngine/scene.gltf#Scene0")),
-        transform: Transform::from_xyz(0.0, -0.5, -2.0),
-        ..Default::default()
-    });
+    commands.spawn((
+        SceneRoot(asset_server.load("models/PlaneEngine/scene.gltf#Scene0")),
+        Transform::from_xyz(0.0, -0.5, -2.0),
+    ));
 
     let text = indoc! {"
         Left Mouse - Pan

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -2,13 +2,14 @@
 
 use bevy::prelude::*;
 use bevy_editor_cam::prelude::*;
+use indoc::indoc;
 
 fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            bevy_mod_picking::DefaultPickingPlugins, // Prerequisite: Use picking plugin
-            DefaultEditorCamPlugins,                 // Step 1: Add camera controller plugin
+            MeshPickingPlugin,
+            DefaultEditorCamPlugins, // Step 1: Add camera controller plugin
         ))
         .add_systems(Startup, (setup_camera, setup_scene))
         .run();
@@ -23,6 +24,7 @@ fn setup_camera(mut commands: Commands, asset_server: Res<AssetServer>) {
             intensity: 1000.0,
             diffuse_map: asset_server.load("environment_maps/diffuse_rgb9e5_zstd.ktx2"),
             specular_map: asset_server.load("environment_maps/specular_rgb9e5_zstd.ktx2"),
+            rotation: default(),
         },
     ));
 }
@@ -33,26 +35,21 @@ fn setup_camera(mut commands: Commands, asset_server: Res<AssetServer>) {
 
 fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(SceneBundle {
-        scene: asset_server.load("models/PlaneEngine/scene.gltf#Scene0"),
+        scene: SceneRoot(asset_server.load("models/PlaneEngine/scene.gltf#Scene0")),
         transform: Transform::from_xyz(0.0, -0.5, -2.0),
         ..Default::default()
     });
 
-    let style = TextStyle {
-        font_size: 20.0,
-        ..default()
-    };
-    commands.spawn(
-        TextBundle::from_sections(vec![
-            TextSection::new("Left Mouse - Pan\n", style.clone()),
-            TextSection::new("Right Mouse - Orbit\n", style.clone()),
-            TextSection::new("Scroll - Zoom\n", style.clone()),
-        ])
-        .with_style(Style {
-            position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+    let text = indoc! {"
+        Left Mouse - Pan
+        Right Mouse - Orbit
+        Scroll - Zoom
+    "};
+    commands.spawn((
+        Text::new(text),
+        TextFont {
+            font_size: 20.0,
             ..default()
-        }),
-    );
+        },
+    ));
 }

--- a/examples/ortho.rs
+++ b/examples/ortho.rs
@@ -14,14 +14,12 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let specular_map = asset_server.load("environment_maps/specular_rgb9e5_zstd.ktx2");
 
     commands.spawn((
-        Camera3dBundle {
-            transform: Transform::from_xyz(10.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
-            projection: Projection::Orthographic(OrthographicProjection {
-                scale: 0.01,
-                ..OrthographicProjection::default_3d()
-            }),
-            ..default()
-        },
+        Camera3d::default(),
+        Transform::from_xyz(10.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+        Projection::Orthographic(OrthographicProjection {
+            scale: 0.01,
+            ..OrthographicProjection::default_3d()
+        }),
         EnvironmentMapLight {
             intensity: 1000.0,
             diffuse_map: diffuse_map.clone(),
@@ -59,12 +57,11 @@ fn spawn_helmets(n: usize, asset_server: &AssetServer, commands: &mut Commands) 
     for x in width.clone() {
         for y in width.clone() {
             for z in width.clone() {
-                commands.spawn((SceneBundle {
-                    scene: SceneRoot(scene.clone()),
-                    transform: Transform::from_translation(IVec3::new(x, y, z).as_vec3() * 2.0)
+                commands.spawn((
+                    SceneRoot(scene.clone()),
+                    Transform::from_translation(IVec3::new(x, y, z).as_vec3() * 2.0)
                         .with_scale(Vec3::splat(1.)),
-                    ..default()
-                },));
+                ));
             }
         }
     }

--- a/examples/ortho.rs
+++ b/examples/ortho.rs
@@ -26,6 +26,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             specular_map: specular_map.clone(),
             rotation: default(),
         },
+        Msaa::Off,
         // This component makes the camera controllable with this plugin.
         //
         // Important: the `with_initial_anchor_depth` is critical for an orthographic camera. Unlike

--- a/examples/ortho.rs
+++ b/examples/ortho.rs
@@ -1,13 +1,10 @@
 use bevy::prelude::*;
 use bevy_editor_cam::prelude::*;
+use indoc::indoc;
 
 fn main() {
     App::new()
-        .add_plugins((
-            DefaultPlugins,
-            bevy_mod_picking::DefaultPickingPlugins,
-            DefaultEditorCamPlugins,
-        ))
+        .add_plugins((DefaultPlugins, MeshPickingPlugin, DefaultEditorCamPlugins))
         .add_systems(Startup, (setup, setup_ui))
         .run();
 }
@@ -21,7 +18,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             transform: Transform::from_xyz(10.0, 10.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
             projection: Projection::Orthographic(OrthographicProjection {
                 scale: 0.01,
-                ..default()
+                ..OrthographicProjection::default_3d()
             }),
             ..default()
         },
@@ -29,6 +26,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             intensity: 1000.0,
             diffuse_map: diffuse_map.clone(),
             specular_map: specular_map.clone(),
+            rotation: default(),
         },
         // This component makes the camera controllable with this plugin.
         //
@@ -62,7 +60,7 @@ fn spawn_helmets(n: usize, asset_server: &AssetServer, commands: &mut Commands) 
         for y in width.clone() {
             for z in width.clone() {
                 commands.spawn((SceneBundle {
-                    scene: scene.clone(),
+                    scene: SceneRoot(scene.clone()),
                     transform: Transform::from_translation(IVec3::new(x, y, z).as_vec3() * 2.0)
                         .with_scale(Vec3::splat(1.)),
                     ..default()
@@ -73,21 +71,16 @@ fn spawn_helmets(n: usize, asset_server: &AssetServer, commands: &mut Commands) 
 }
 
 fn setup_ui(mut commands: Commands) {
-    let style = TextStyle {
-        font_size: 20.0,
-        ..default()
-    };
-    commands.spawn(
-        TextBundle::from_sections(vec![
-            TextSection::new("Left Mouse - Pan\n", style.clone()),
-            TextSection::new("Right Mouse - Orbit\n", style.clone()),
-            TextSection::new("Scroll - Zoom\n", style.clone()),
-        ])
-        .with_style(Style {
-            position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+    let text = indoc! {"
+        Left Mouse - Pan
+        Right Mouse - Orbit
+        Scroll - Zoom
+    "};
+    commands.spawn((
+        Text::new(text),
+        TextFont {
+            font_size: 20.0,
             ..default()
-        }),
-    );
+        },
+    ));
 }

--- a/examples/pseudo_ortho.rs
+++ b/examples/pseudo_ortho.rs
@@ -27,6 +27,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             hdr: true,
             ..Default::default()
         },
+        Msaa::Off,
         EnvironmentMapLight {
             intensity: 1000.0,
             diffuse_map: diffuse_map.clone(),

--- a/examples/pseudo_ortho.rs
+++ b/examples/pseudo_ortho.rs
@@ -17,17 +17,15 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let specular_map = asset_server.load("environment_maps/specular_rgb9e5_zstd.ktx2");
 
     commands.spawn((
-        Camera3dBundle {
-            transform: Transform::from_xyz(1000.0, 1000.0, 1000.0).looking_at(Vec3::ZERO, Vec3::Y),
-            projection: Projection::Perspective(PerspectiveProjection {
-                fov: 0.001,
-                ..default()
-            }),
-            camera: Camera {
-                hdr: true,
-                ..Default::default()
-            },
+        Camera3d::default(),
+        Transform::from_xyz(1000.0, 1000.0, 1000.0).looking_at(Vec3::ZERO, Vec3::Y),
+        Projection::Perspective(PerspectiveProjection {
+            fov: 0.001,
             ..default()
+        }),
+        Camera {
+            hdr: true,
+            ..Default::default()
         },
         EnvironmentMapLight {
             intensity: 1000.0,
@@ -56,12 +54,11 @@ fn spawn_gltf(n: usize, asset_server: &AssetServer, commands: &mut Commands) {
     for x in width.clone() {
         for y in width.clone() {
             for z in width.clone() {
-                commands.spawn((SceneBundle {
-                    scene: SceneRoot(scene.clone()),
-                    transform: Transform::from_translation(IVec3::new(x, y, z).as_vec3() * 2.0)
+                commands.spawn((
+                    SceneRoot(scene.clone()),
+                    Transform::from_translation(IVec3::new(x, y, z).as_vec3() * 2.0)
                         .with_scale(Vec3::splat(1.)),
-                    ..default()
-                },));
+                ));
             }
         }
     }

--- a/examples/pseudo_ortho.rs
+++ b/examples/pseudo_ortho.rs
@@ -3,14 +3,11 @@
 
 use bevy::prelude::*;
 use bevy_editor_cam::prelude::*;
+use indoc::indoc;
 
 fn main() {
     App::new()
-        .add_plugins((
-            DefaultPlugins,
-            bevy_mod_picking::DefaultPickingPlugins,
-            DefaultEditorCamPlugins,
-        ))
+        .add_plugins((DefaultPlugins, MeshPickingPlugin, DefaultEditorCamPlugins))
         .add_systems(Startup, (setup, setup_ui))
         .run();
 }
@@ -36,6 +33,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             intensity: 1000.0,
             diffuse_map: diffuse_map.clone(),
             specular_map: specular_map.clone(),
+            rotation: default(),
         },
         // This component makes the camera controllable with this plugin:
         EditorCam::default(),
@@ -59,7 +57,7 @@ fn spawn_gltf(n: usize, asset_server: &AssetServer, commands: &mut Commands) {
         for y in width.clone() {
             for z in width.clone() {
                 commands.spawn((SceneBundle {
-                    scene: scene.clone(),
+                    scene: SceneRoot(scene.clone()),
                     transform: Transform::from_translation(IVec3::new(x, y, z).as_vec3() * 2.0)
                         .with_scale(Vec3::splat(1.)),
                     ..default()
@@ -70,21 +68,16 @@ fn spawn_gltf(n: usize, asset_server: &AssetServer, commands: &mut Commands) {
 }
 
 fn setup_ui(mut commands: Commands) {
-    let style = TextStyle {
-        font_size: 20.0,
-        ..default()
-    };
-    commands.spawn(
-        TextBundle::from_sections(vec![
-            TextSection::new("Left Mouse - Pan\n", style.clone()),
-            TextSection::new("Right Mouse - Orbit\n", style.clone()),
-            TextSection::new("Scroll - Zoom\n", style.clone()),
-        ])
-        .with_style(Style {
-            position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+    let text = indoc! {"
+        Left Mouse - Pan
+        Right Mouse - Orbit
+        Scroll - Zoom
+    "};
+    commands.spawn((
+        Text::new(text),
+        TextFont {
+            font_size: 20.0,
             ..default()
-        }),
-    );
+        },
+    ));
 }

--- a/examples/split_screen.rs
+++ b/examples/split_screen.rs
@@ -23,13 +23,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // Left Camera
     commands.spawn((
-        Camera3dBundle {
-            transform: Transform::from_xyz(0.0, 2.0, -1.0).looking_at(Vec3::ZERO, Vec3::Y),
-            camera: Camera {
-                hdr: true,
-                clear_color: ClearColorConfig::None,
-                ..default()
-            },
+        Camera3d::default(),
+        Transform::from_xyz(0.0, 2.0, -1.0).looking_at(Vec3::ZERO, Vec3::Y),
+        Camera {
+            hdr: true,
+            clear_color: ClearColorConfig::None,
             ..default()
         },
         EnvironmentMapLight {
@@ -48,23 +46,21 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // Right Camera
     commands.spawn((
-        Camera3dBundle {
-            transform: Transform::from_xyz(1.0, 1.0, 1.5).looking_at(Vec3::ZERO, Vec3::Y),
-            camera: Camera {
-                // Renders the right camera after the left camera, which has a default priority of 0
-                order: 10,
-                hdr: true,
-                // don't clear on the second camera because the first camera already cleared the window
-                clear_color: ClearColorConfig::None,
-                ..default()
-            },
-            projection: Projection::Orthographic(OrthographicProjection {
-                scale: 0.01,
-                ..OrthographicProjection::default_3d()
-            }),
-            tonemapping: Tonemapping::AcesFitted,
+        Camera3d::default(),
+        Transform::from_xyz(1.0, 1.0, 1.5).looking_at(Vec3::ZERO, Vec3::Y),
+        Camera {
+            // Renders the right camera after the left camera, which has a default priority of 0
+            order: 10,
+            hdr: true,
+            // don't clear on the second camera because the first camera already cleared the window
+            clear_color: ClearColorConfig::None,
             ..default()
         },
+        Projection::Orthographic(OrthographicProjection {
+            scale: 0.01,
+            ..OrthographicProjection::default_3d()
+        }),
+        Tonemapping::AcesFitted,
         EnvironmentMapLight {
             intensity: 1000.0,
             diffuse_map: diffuse_map.clone(),
@@ -123,12 +119,11 @@ fn spawn_helmets(n: usize, asset_server: &AssetServer, commands: &mut Commands) 
     for x in width.clone() {
         for y in width.clone() {
             for z in width.clone() {
-                commands.spawn((SceneBundle {
-                    scene: SceneRoot(scene.clone()),
-                    transform: Transform::from_translation(IVec3::new(x, y, z).as_vec3() * 2.0)
+                commands.spawn((
+                    SceneRoot(scene.clone()),
+                    Transform::from_translation(IVec3::new(x, y, z).as_vec3() * 2.0)
                         .with_scale(Vec3::splat(1.)),
-                    ..default()
-                },));
+                ));
             }
         }
     }

--- a/examples/split_screen.rs
+++ b/examples/split_screen.rs
@@ -8,11 +8,7 @@ use bevy_editor_cam::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins((
-            DefaultPlugins,
-            bevy_mod_picking::DefaultPickingPlugins,
-            DefaultEditorCamPlugins,
-        ))
+        .add_plugins((DefaultPlugins, MeshPickingPlugin, DefaultEditorCamPlugins))
         .add_systems(Startup, setup)
         .add_systems(Update, set_camera_viewports)
         .run();
@@ -40,6 +36,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             intensity: 1000.0,
             diffuse_map: diffuse_map.clone(),
             specular_map: specular_map.clone(),
+            rotation: default(),
         },
         EditorCam::default(),
         bevy_editor_cam::extensions::independent_skybox::IndependentSkybox::new(
@@ -63,7 +60,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             },
             projection: Projection::Orthographic(OrthographicProjection {
                 scale: 0.01,
-                ..default()
+                ..OrthographicProjection::default_3d()
             }),
             tonemapping: Tonemapping::AcesFitted,
             ..default()
@@ -72,6 +69,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             intensity: 1000.0,
             diffuse_map: diffuse_map.clone(),
             specular_map: specular_map.clone(),
+            rotation: default(),
         },
         EditorCam::default(),
         bevy_editor_cam::extensions::independent_skybox::IndependentSkybox::new(diffuse_map, 500.0),
@@ -126,7 +124,7 @@ fn spawn_helmets(n: usize, asset_server: &AssetServer, commands: &mut Commands) 
         for y in width.clone() {
             for z in width.clone() {
                 commands.spawn((SceneBundle {
-                    scene: scene.clone(),
+                    scene: SceneRoot(scene.clone()),
                     transform: Transform::from_translation(IVec3::new(x, y, z).as_vec3() * 2.0)
                         .with_scale(Vec3::splat(1.)),
                     ..default()

--- a/examples/zoom_limits.rs
+++ b/examples/zoom_limits.rs
@@ -74,7 +74,6 @@ fn setup_ui(mut commands: Commands) {
             font_size: 20.0,
             ..default()
         },
-        // TargetCamera(camera),
     ));
 }
 

--- a/examples/zoom_limits.rs
+++ b/examples/zoom_limits.rs
@@ -15,7 +15,7 @@ fn main() {
 
 fn setup_camera(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
-        Camera3dBundle::default(),
+        Camera3d::default(),
         EditorCam {
             zoom_limits: ZoomLimits {
                 min_size_per_pixel: 0.0001,
@@ -59,12 +59,11 @@ fn setup_scene(
     let mesh = meshes.add(Cuboid::from_size(Vec3::new(1.0, 1.0, 0.1)));
 
     for i in 1..5 {
-        commands.spawn(PbrBundle {
-            mesh: Mesh3d(mesh.clone()),
-            material: MeshMaterial3d(material.clone()),
-            transform: Transform::from_xyz(0.0, 0.0, -2.0 * i as f32),
-            ..default()
-        });
+        commands.spawn((
+            Mesh3d(mesh.clone()),
+            MeshMaterial3d(material.clone()),
+            Transform::from_xyz(0.0, 0.0, -2.0 * i as f32),
+        ));
     }
 }
 

--- a/examples/zoom_limits.rs
+++ b/examples/zoom_limits.rs
@@ -1,17 +1,13 @@
 //! A minimal example demonstrating setting zoom limits and zooming through objects.
 
 use bevy::prelude::*;
-use bevy_color::palettes;
 use bevy_editor_cam::{extensions::dolly_zoom::DollyZoomTrigger, prelude::*};
+use indoc::formatdoc;
 use zoom::ZoomLimits;
 
 fn main() {
     App::new()
-        .add_plugins((
-            DefaultPlugins,
-            bevy_mod_picking::DefaultPickingPlugins,
-            DefaultEditorCamPlugins,
-        ))
+        .add_plugins((DefaultPlugins, MeshPickingPlugin, DefaultEditorCamPlugins))
         .add_systems(Startup, (setup_camera, setup_scene, setup_ui))
         .add_systems(Update, (toggle_projection, toggle_zoom))
         .run();
@@ -32,6 +28,7 @@ fn setup_camera(mut commands: Commands, asset_server: Res<AssetServer>) {
             intensity: 1000.0,
             diffuse_map: asset_server.load("environment_maps/diffuse_rgb9e5_zstd.ktx2"),
             specular_map: asset_server.load("environment_maps/specular_rgb9e5_zstd.ktx2"),
+            rotation: default(),
         },
     ));
 }
@@ -45,11 +42,7 @@ fn toggle_zoom(
         let mut editor = cam.single_mut();
         editor.zoom_limits.zoom_through_objects = !editor.zoom_limits.zoom_through_objects;
         let mut text = text.single_mut();
-        text.sections.last_mut().unwrap().value = if editor.zoom_limits.zoom_through_objects {
-            "Zoom Through: Enabled".into()
-        } else {
-            "Zoom Through: Disabled".into()
-        };
+        *text = Text::new(help_text(editor.zoom_limits.zoom_through_objects));
     }
 }
 
@@ -67,8 +60,8 @@ fn setup_scene(
 
     for i in 1..5 {
         commands.spawn(PbrBundle {
-            mesh: mesh.clone(),
-            material: material.clone(),
+            mesh: Mesh3d(mesh.clone()),
+            material: MeshMaterial3d(material.clone()),
             transform: Transform::from_xyz(0.0, 0.0, -2.0 * i as f32),
             ..default()
         });
@@ -76,43 +69,25 @@ fn setup_scene(
 }
 
 fn setup_ui(mut commands: Commands) {
-    let style = TextStyle {
-        font_size: 20.0,
-        ..default()
-    };
-    commands
-        .spawn((
-            // TargetCamera(camera),
-            NodeBundle {
-                style: Style {
-                    width: Val::Percent(100.),
-                    height: Val::Percent(100.),
-                    padding: UiRect::all(Val::Px(20.)),
-                    ..default()
-                },
-                ..default()
-            },
-        ))
-        .with_children(|parent| {
-            parent.spawn(
-                TextBundle::from_sections(vec![
-                    TextSection::new("Left Mouse - Pan\n", style.clone()),
-                    TextSection::new("Right Mouse - Orbit\n", style.clone()),
-                    TextSection::new("Scroll - Zoom\n", style.clone()),
-                    TextSection::new("P - Toggle projection\n", style.clone()),
-                    TextSection::new("Z - Toggle zoom through object setting\n", style.clone()),
-                    TextSection::new(
-                        "Zoom Through: Enabled\n",
-                        TextStyle {
-                            font_size: 20.0,
-                            color: palettes::basic::YELLOW.into(),
-                            ..default()
-                        },
-                    ),
-                ])
-                .with_style(Style { ..default() }),
-            );
-        });
+    commands.spawn((
+        Text::new(help_text(true)),
+        TextFont {
+            font_size: 20.0,
+            ..default()
+        },
+        // TargetCamera(camera),
+    ));
+}
+
+fn help_text(zoom_through: bool) -> String {
+    formatdoc! {"
+        Left Mouse - Pan
+        Right Mouse - Orbit
+        Scroll - Zoom
+        P - Toggle projection
+        Z - Toggle zoom through object setting
+        Zoom Through: {zoom_through}
+    "}
 }
 
 fn toggle_projection(
@@ -124,7 +99,7 @@ fn toggle_projection(
     if keys.just_pressed(KeyCode::KeyP) {
         *toggled = !*toggled;
         let target_projection = if *toggled {
-            Projection::Orthographic(OrthographicProjection::default())
+            Projection::Orthographic(OrthographicProjection::default_3d())
         } else {
             Projection::Perspective(PerspectiveProjection::default())
         };

--- a/src/controller/component.rs
+++ b/src/controller/component.rs
@@ -31,7 +31,7 @@ use super::{
 /// # Moving the Camera
 ///
 /// The [`EditorCamPlugin`](crate::DefaultEditorCamPlugins) will automatically handle sending inputs
-/// to the camera controller using [`bevy_picking_core`] to compute pointer hit locations for mouse,
+/// to the camera controller using [`bevy_picking`] to compute pointer hit locations for mouse,
 /// touch, and pen inputs. The picking plugin allows you to specify your own picking backend, or
 /// choose from a variety of provided backends. This is important because this camera controller
 /// relies on depth information for each pointer, and using the picking plugin means it can do this

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -26,7 +26,7 @@ impl Plugin for MinimalEditorCamPlugin {
                 crate::controller::projections::update_perspective,
             )
                 .chain()
-                .after(bevy_picking_core::PickSet::Last),
+                .after(bevy_picking::PickSet::Last),
         )
         .register_type::<component::EditorCam>();
     }

--- a/src/extensions/anchor_indicator.rs
+++ b/src/extensions/anchor_indicator.rs
@@ -80,8 +80,7 @@ pub fn draw_anchor(
             let arm_length = 0.4;
 
             gizmos.circle(
-                anchor_world,
-                Dir3::new_unchecked(cam_transform.forward().normalize()),
+                Isometry3d::new(anchor_world, cam_transform.rotation()),
                 scale,
                 gizmo_color(),
             );

--- a/src/extensions/dolly_zoom.rs
+++ b/src/extensions/dolly_zoom.rs
@@ -238,7 +238,7 @@ fn ortho_tri_base_to_scale_factor(camera: &Camera, ortho: &OrthographicProjectio
     if let Some(size) = camera.logical_viewport_size() {
         let (width, height) = (size.x as f64, size.y as f64);
         2.0 / match ortho.scaling_mode {
-            ScalingMode::WindowSize(pixel_scale) => height / pixel_scale as f64,
+            ScalingMode::WindowSize => height,
             ScalingMode::AutoMin {
                 min_width,
                 min_height,
@@ -259,8 +259,10 @@ fn ortho_tri_base_to_scale_factor(camera: &Camera, ortho: &OrthographicProjectio
                     height * max_width as f64 / width
                 }
             }
-            ScalingMode::FixedVertical(viewport_height) => viewport_height as f64,
-            ScalingMode::FixedHorizontal(viewport_width) => height * viewport_width as f64 / width,
+            ScalingMode::FixedVertical { viewport_height } => viewport_height as f64,
+            ScalingMode::FixedHorizontal { viewport_width } => {
+                height * viewport_width as f64 / width
+            }
             ScalingMode::Fixed { height, .. } => height as f64,
         }
     } else {

--- a/src/extensions/independent_skybox.rs
+++ b/src/extensions/independent_skybox.rs
@@ -9,6 +9,7 @@ use bevy_app::prelude::*;
 use bevy_asset::Handle;
 use bevy_core_pipeline::{prelude::*, Skybox};
 use bevy_ecs::prelude::*;
+use bevy_image::Image;
 use bevy_reflect::prelude::*;
 use bevy_render::{prelude::*, view::RenderLayers};
 use bevy_transform::prelude::*;
@@ -118,26 +119,25 @@ impl IndependentSkyboxCamera {
 
             let entity = commands
                 .spawn((
-                    Camera3dBundle {
-                        camera: Camera {
-                            order: camera.order + editor_without_skybox.skybox_cam_order_offset,
-                            hdr: true,
-                            clear_color: ClearColorConfig::None,
-                            ..Default::default()
-                        },
-                        projection: Projection::Perspective(PerspectiveProjection {
-                            fov: match editor_without_skybox.fov {
-                                SkyboxFov::Auto => PerspectiveProjection::default().fov,
-                                SkyboxFov::Fixed(fov) => fov,
-                            },
-                            ..Default::default()
-                        }),
+                    Camera3d::default(),
+                    Camera {
+                        order: camera.order + editor_without_skybox.skybox_cam_order_offset,
+                        hdr: true,
+                        clear_color: ClearColorConfig::None,
                         ..Default::default()
                     },
+                    Projection::Perspective(PerspectiveProjection {
+                        fov: match editor_without_skybox.fov {
+                            SkyboxFov::Auto => PerspectiveProjection::default().fov,
+                            SkyboxFov::Fixed(fov) => fov,
+                        },
+                        ..Default::default()
+                    }),
                     RenderLayers::none(),
                     Skybox {
                         image: editor_without_skybox.skybox.clone(),
                         brightness: editor_without_skybox.brightness,
+                        rotation: Default::default(),
                     },
                     IndependentSkyboxCamera {
                         driven_by: editor_cam_entity,

--- a/src/extensions/independent_skybox.rs
+++ b/src/extensions/independent_skybox.rs
@@ -126,6 +126,7 @@ impl IndependentSkyboxCamera {
                         clear_color: ClearColorConfig::None,
                         ..Default::default()
                     },
+                    Msaa::Off,
                     Projection::Perspective(PerspectiveProjection {
                         fov: match editor_without_skybox.fov {
                             SkyboxFov::Auto => PerspectiveProjection::default().fov,

--- a/src/input.rs
+++ b/src/input.rs
@@ -14,8 +14,8 @@ use bevy_transform::prelude::*;
 use bevy_utils::hashbrown::HashMap;
 use bevy_window::PrimaryWindow;
 
-use bevy_picking_core::pointer::{
-    InputMove, PointerId, PointerInteraction, PointerLocation, PointerMap,
+use bevy_picking::pointer::{
+    PointerAction, PointerId, PointerInput, PointerInteraction, PointerLocation, PointerMap,
 };
 
 use crate::prelude::{component::EditorCam, inputs::MotionInputs};
@@ -59,7 +59,7 @@ impl Plugin for DefaultInputPlugin {
                     EditorCamInputEvent::send_pointer_inputs,
                 )
                     .chain()
-                    .after(bevy_picking_core::PickSet::Last)
+                    .after(bevy_picking::PickSet::Last)
                     .before(crate::controller::component::EditorCam::update_camera_positions),
             )
             .register_type::<CameraPointerMap>()
@@ -273,7 +273,7 @@ impl EditorCamInputEvent {
         camera_map: Res<CameraPointerMap>,
         mut camera_controllers: Query<&mut EditorCam>,
         mut mouse_wheel: EventReader<MouseWheel>,
-        mut moves: EventReader<InputMove>,
+        mut moves: EventReader<PointerInput>,
     ) {
         let moves_list: Vec<_> = moves.read().collect();
         for (pointer, camera) in camera_map.iter() {
@@ -284,7 +284,11 @@ impl EditorCamInputEvent {
             let screenspace_input = moves_list
                 .iter()
                 .filter(|m| m.pointer_id.eq(pointer))
-                .map(|m| m.delta)
+                .filter_map(|m| match m.action {
+                    PointerAction::Moved { delta } => Some(delta),
+                    PointerAction::Pressed { .. } => None,
+                    PointerAction::Canceled => None,
+                })
                 .sum();
 
             let zoom_amount = match pointer {

--- a/src/input.rs
+++ b/src/input.rs
@@ -292,7 +292,8 @@ impl EditorCamInputEvent {
                 .sum();
 
             let zoom_amount = match pointer {
-                // TODO: add pinch zoom support, probably in mod_picking
+                // TODO: add pinch zoom support, probably in bevy_picking
+                //   https://github.com/bevyengine/bevy/issues/6174
                 PointerId::Mouse => mouse_wheel
                     .read()
                     .map(|mw| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,17 +97,18 @@
 //!
 //! # Usage
 //!
-//! This plugin only requires three things to work. The `bevy_mod_picking` plugin for hit tests, the
+//! This plugin only requires three things to work. The [`bevy_picking::DefaultPickingPlugins`] for hit tests, the
 //! [`DefaultEditorCamPlugins`] plugin group, and the [`EditorCam`](crate::prelude::EditorCam)
 //! component. Controller settings are configured per-camera in the
 //! [`EditorCam`](crate::prelude::EditorCam) component.
 //!
 //! ## Getting Started
 //!
-//! #### 1. Add `bevy_mod_picking`
+//! #### 1. Add [`bevy_picking`]
 //!
-//! The camera controller uses [`bevy_picking_core`] for pointer interactions. If you already use
-//! the picking plugin, then using this camera controller is essentially free because it can reuse
+//! The camera controller uses [`bevy_picking`] for pointer interactions. If you already use
+//! the picking plugin (which is included in [`bevy::DefaultPlugins`]),
+//! then using this camera controller is essentially free because it can reuse
 //! those same hit tests you are already running.
 //!
 //! If you are not using the picking plugin yet, all you need to get started are the default
@@ -115,7 +116,7 @@
 //!
 //! ```
 //! # let mut app = bevy::app::App::new();
-//! app.add_plugins(bevy_mod_picking::DefaultPickingPlugins);
+//! app.add_plugins(bevy::picking::DefaultPickingPlugins);
 //! ```
 //!
 //! #### 2. Add `DefaultEditorCamPlugins`
@@ -167,10 +168,10 @@
 //! ### Pointer and Hit Test Agnostic
 //!
 //! Users of this library shouldn't be forced into using any particular hit testing method, like CPU
-//! raycasting. The controller uses [`bevy_picking_core`] to work with:
+//! raycasting. The controller uses [`bevy_picking`] to work with:
 //!
 //! - Arbitrary hit testing backends, including those written by users. See
-//!   [`bevy_picking_core::backend`] for more information.
+//!   [`bevy_picking::backend`] for more information.
 //! - Any number of pointing inputs, including touch.
 //! - Viewports and multi-pass rendering.
 


### PR DESCRIPTION
- [x] Make the crate itself compile without warnings
- [x] Work around a bug in bevy_gltf
- [x] Make the examples run (with deprecation warnings)
- [x] Fix deprecation warnings
- [x] Bump crate version
- [x] Update the bevy version support table
- [x] Update documentation (replace bevy_mod_picking with bevy::picking)
- This PR is based on https://github.com/aevyrie/bevy_editor_cam/pull/27

## Notes

### Msaa

- Msaa clashes with temporal antialiasing, that's by design :ok_hand: : I had to remove Msaa from cameras, because this component is added by default to cameras.
- But it also clashes with `IndependentSkybox`, which is surprising as it didn't clash before :thinking: 
  - So I decided to remove `Msaa` entirely on examples using `IndependentSkybox`, as I don't have a better fix.
  
### loading blink + anchor bug

- I was able to reproduce it on main branch, so I opened an issue: https://github.com/aevyrie/bevy_editor_cam/issues/30