### PR TITLE
feat: Add `SyncCameraPosition` system set for 0.6.0.

### DIFF
--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -23,10 +23,14 @@ impl Plugin for MinimalEditorCamPlugin {
             (
                 crate::controller::component::EditorCam::update_camera_positions,
                 crate::controller::projections::update_orthographic,
+                // Technically `update_perspective` does not alter the camera
+                // position, but the other two systems above do, so I'm putting
+                // them all in the SyncCameraPosition group.
                 crate::controller::projections::update_perspective,
             )
                 .chain()
-                .after(bevy_picking::PickSet::Last),
+                .after(bevy_picking::PickSet::Last)
+                .in_set(crate::SyncCameraPosition),
         )
         .register_type::<component::EditorCam>();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,9 +181,14 @@ pub mod prelude {
 }
 
 use bevy_app::{prelude::*, PluginGroupBuilder};
+use bevy_ecs::prelude::SystemSet;
 
 /// Adds [`bevy_editor_cam`](crate) functionality with all extensions and the default input plugin.
 pub struct DefaultEditorCamPlugins;
+
+/// This system set may alter the camera position in the `PreUpdate` schedule.
+#[derive(SystemSet, Default, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SyncCameraPosition;
 
 impl PluginGroup for DefaultEditorCamPlugins {
     #[allow(clippy::let_and_return)] // Needed for conditional compilation


### PR DESCRIPTION
This is a cherry pick of PR #52 applied to the 0.6.0 version of bevy_editor_cam. Our app is still using Bevy 0.16, so we'd be grateful for a 0.6.1 release that included this patch.