### PR TITLE
Custom transform component support

### DIFF
--- a/examples/cad.rs
+++ b/examples/cad.rs
@@ -17,6 +17,7 @@ use bevy_editor_cam::{
     extensions::{dolly_zoom::DollyZoomTrigger, look_to::LookToTrigger},
     prelude::*,
 };
+use bevy_math::DVec3;
 use bevy_render::view::Hdr;
 
 fn main() {
@@ -117,14 +118,14 @@ fn toggle_constraint(
             OrbitConstraint::Fixed { .. } => editor.orbit_constraint = OrbitConstraint::Free,
             OrbitConstraint::Free => {
                 editor.orbit_constraint = OrbitConstraint::Fixed {
-                    up: Vec3::Y,
+                    up: DVec3::Y,
                     can_pass_tdc: false,
                 };
 
                 look_to.write(LookToTrigger::auto_snap_up_direction(
-                    transform.forward(),
+                    transform.forward().as_dvec3(),
                     entity,
-                    transform,
+                    &transform.rotation.as_dquat(),
                     editor.as_ref(),
                 ));
             }
@@ -140,49 +141,49 @@ fn switch_direction(
     let (camera, transform, editor) = cam.single().unwrap();
     if keys.just_pressed(KeyCode::Digit1) {
         look_to.write(LookToTrigger::auto_snap_up_direction(
-            Dir3::X,
+            DVec3::X,
             camera,
-            transform,
+            &transform.rotation.as_dquat(),
             editor,
         ));
     }
     if keys.just_pressed(KeyCode::Digit2) {
         look_to.write(LookToTrigger::auto_snap_up_direction(
-            Dir3::Z,
+            DVec3::Z,
             camera,
-            transform,
+            &transform.rotation.as_dquat(),
             editor,
         ));
     }
     if keys.just_pressed(KeyCode::Digit3) {
         look_to.write(LookToTrigger::auto_snap_up_direction(
-            Dir3::NEG_X,
+            DVec3::NEG_X,
             camera,
-            transform,
+            &transform.rotation.as_dquat(),
             editor,
         ));
     }
     if keys.just_pressed(KeyCode::Digit4) {
         look_to.write(LookToTrigger::auto_snap_up_direction(
-            Dir3::NEG_Z,
+            DVec3::NEG_Z,
             camera,
-            transform,
+            &transform.rotation.as_dquat(),
             editor,
         ));
     }
     if keys.just_pressed(KeyCode::Digit5) {
         look_to.write(LookToTrigger::auto_snap_up_direction(
-            Dir3::Y,
+            DVec3::Y,
             camera,
-            transform,
+            &transform.rotation.as_dquat(),
             editor,
         ));
     }
     if keys.just_pressed(KeyCode::Digit6) {
         look_to.write(LookToTrigger::auto_snap_up_direction(
-            Dir3::NEG_Y,
+            DVec3::NEG_Y,
             camera,
-            transform,
+            &transform.rotation.as_dquat(),
             editor,
         ));
     }

--- a/examples/map.rs
+++ b/examples/map.rs
@@ -4,6 +4,7 @@
 //! in 2d maps, with momentum and pixel-perfect panning, when used with ortho.
 use bevy::{color::palettes, prelude::*};
 use bevy_editor_cam::{extensions::dolly_zoom::DollyZoomTrigger, prelude::*};
+use bevy_math::DVec3;
 use rand::Rng;
 
 fn main() {
@@ -43,7 +44,7 @@ fn setup(
         },
         EditorCam {
             orbit_constraint: OrbitConstraint::Fixed {
-                up: Vec3::Y,
+                up: DVec3::Y,
                 can_pass_tdc: false,
             },
             last_anchor_depth: -translation.length() as f64,

--- a/examples/map.rs
+++ b/examples/map.rs
@@ -4,8 +4,8 @@
 //! in 2d maps, with momentum and pixel-perfect panning, when used with ortho.
 use bevy::{color::palettes, prelude::*};
 use bevy_editor_cam::{extensions::dolly_zoom::DollyZoomTrigger, prelude::*};
-use rand::RngExt;
 use bevy_math::DVec3;
+use rand::RngExt;
 
 fn main() {
     App::new()

--- a/src/controller/component.rs
+++ b/src/controller/component.rs
@@ -341,7 +341,7 @@ impl EditorCam {
                     .p1()
                     .get_mut(*entity)
                     .ok()
-                    .map(|(mut camera_controller, camera, projection)| {
+                    .and_then(|(mut camera_controller, camera, projection)| {
                         let dt = time.delta();
                         camera_controller.update_transform_and_projection(
                             camera,
@@ -352,8 +352,7 @@ impl EditorCam {
                             dt,
                         )
                     })
-                    .flatten()
-                    .map(|transform| (entity.clone(), transform))
+                    .map(|transform| (*entity, transform))
             })
             .collect::<Vec<_>>()
             .iter()

--- a/src/controller/component.rs
+++ b/src/controller/component.rs
@@ -348,7 +348,7 @@ impl EditorCam {
                     .p1()
                     .get_mut(*entity)
                     .ok()
-                    .map(|(mut camera_controller, camera, ref mut projection)| {
+                    .map(|(mut camera_controller, camera, projection)| {
                         let dt = time.delta();
                         camera_controller.update_transform_and_projection(
                             camera,
@@ -553,36 +553,13 @@ impl EditorCam {
             .mul_vec3(orbit_dir.cross(DVec3::NEG_Z).normalize())
             .normalize();
 
-        let rotate_around = |cam_translation: &mut DVec3,
-                             cam_rotation: &mut DQuat,
-                             point: DVec3,
-                             rotation: DQuat| {
-            // Following lines are f64 versions of Transform::rotate_around
-            *cam_translation = point + rotation * (*cam_translation - point);
-            *cam_rotation = (rotation * *cam_rotation).normalize();
-        };
-
-        let look_to = |cam_rotation: &mut DQuat, direction: DVec3, up: DVec3| {
-            // Following lines are f64 versions of Transform::look_to
-            let back = -direction;
-            let right = up
-                .cross(back)
-                .try_normalize()
-                .unwrap_or_else(|| up.any_orthogonal_vector());
-            let up = back.cross(right);
-            *cam_rotation = DQuat::from_mat3(&DMat3::from_cols(right, up, back))
-        };
-
-        let cam_forward = |cam_rotation: DQuat| -> DVec3 { cam_rotation * DVec3::NEG_Z };
-        let cam_left = |cam_rotation: DQuat| -> DVec3 { cam_rotation * DVec3::NEG_X };
-        let cam_up = |cam_rotation: DQuat| -> DVec3 { cam_rotation * DVec3::Y };
-
         let orbit_multiplier = 0.005;
         if orbit.is_finite() && orbit.length() != 0.0 {
             match self.orbit_constraint {
                 OrbitConstraint::Fixed { up, can_pass_tdc } => {
                     let epsilon = 1e-3;
                     let motion_threshold = 1e-5;
+
                     let angle_to_bdc = cam_forward(new_rotation).angle_between(up);
                     let angle_to_tdc = cam_forward(new_rotation).angle_between(-up);
                     let pitch_angle = {
@@ -611,24 +588,22 @@ impl EditorCam {
                     match [pitch == DQuat::IDENTITY, yaw == DQuat::IDENTITY] {
                         [true, true] => (),
                         [true, false] => rotate_around(
-                            &mut new_translation,
-                            &mut new_rotation,
+                            (&mut new_translation, &mut new_rotation),
                             anchor_world,
                             yaw,
                         ),
                         [false, true] => rotate_around(
-                            &mut new_translation,
-                            &mut new_rotation,
+                            (&mut new_translation, &mut new_rotation),
                             anchor_world,
                             pitch,
                         ),
                         [false, false] => rotate_around(
-                            &mut new_translation,
-                            &mut new_rotation,
+                            (&mut new_translation, &mut new_rotation),
                             anchor_world,
                             yaw * pitch,
                         ),
                     };
+
                     let how_upright = cam_up(new_rotation).angle_between(up).abs() as f32;
                     // Orient the camera so up always points up (roll).
                     let forward = cam_forward(new_rotation);
@@ -642,8 +617,7 @@ impl EditorCam {
                     let rotation =
                         DQuat::from_axis_angle(orbit_axis_world, orbit.length() * orbit_multiplier);
                     rotate_around(
-                        &mut new_translation,
-                        &mut new_rotation,
+                        (&mut new_translation, &mut new_rotation),
                         anchor_world,
                         rotation,
                     );
@@ -743,21 +717,33 @@ impl EditorCam {
 }
 
 /// A 64-bit version of Transform::rotate_around
-pub fn rotate_around(transform: &mut Transform, point: DVec3, rotation: DQuat) {
-    transform.translation =
-        (point + rotation * (transform.translation.as_dvec3() - point)).as_vec3();
-    transform.rotation = (rotation * transform.rotation.as_dquat())
-        .as_quat()
-        .normalize();
+pub fn rotate_around(transform: (&mut DVec3, &mut DQuat), point: DVec3, rotation: DQuat) {
+    *transform.0 = point + rotation * (*transform.0 - point);
+    *transform.1 = (rotation * *transform.1).normalize();
 }
 
-/// A 64-bit version of Transform::rotate_around
-pub fn rotate_around(transform: &mut Transform, point: DVec3, rotation: DQuat) {
-    transform.translation =
-        (point + rotation * (transform.translation.as_dvec3() - point)).as_vec3();
-    transform.rotation = (rotation * transform.rotation.as_dquat())
-        .as_quat()
-        .normalize();
+/// A 64-bit version of Transform::look_to
+pub fn look_to(cam_rotation: &mut DQuat, direction: DVec3, up: DVec3) {
+    let back = -direction;
+    let right = up
+        .cross(back)
+        .try_normalize()
+        .unwrap_or_else(|| up.any_orthogonal_vector());
+    let up = back.cross(right);
+    *cam_rotation = DQuat::from_mat3(&DMat3::from_cols(right, up, back))
+}
+
+/// Helper method for getting a local forward vector
+pub fn cam_forward(cam_rotation: DQuat) -> DVec3 {
+    cam_rotation * DVec3::NEG_Z
+}
+/// Helper method for getting a local left vector
+pub fn cam_left(cam_rotation: DQuat) -> DVec3 {
+    cam_rotation * DVec3::NEG_X
+}
+/// Helper method for getting a local up vector
+pub fn cam_up(cam_rotation: DQuat) -> DVec3 {
+    cam_rotation * DVec3::Y
 }
 
 /// Settings that define how camera orbit behaves.

--- a/src/controller/component.rs
+++ b/src/controller/component.rs
@@ -8,7 +8,7 @@ use std::{
 use bevy_camera::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_log::prelude::*;
-use bevy_math::{prelude::*, DMat4, DQuat, DVec2, DVec3};
+use bevy_math::{prelude::*, DAffine3, DMat3, DMat4, DQuat, DVec2, DVec3};
 use bevy_platform::time::Instant;
 use bevy_reflect::prelude::*;
 use bevy_time::prelude::*;
@@ -80,6 +80,16 @@ pub struct EditorCam {
     pub current_motion: CurrentMotion,
 }
 
+/// Optional resource that holds a function for how ['EditorCam'] applies its transform changes.
+/// The intended usage is for situations where a different transform system than Bevy's ['Transform'] component is being used
+/// When this resource is not present, the behavior falls back to a default that uses Bevy's ['Transform'].
+#[derive(Resource)]
+pub struct CustomReadWrite {
+    /// Function for reading transform info from an entity.
+    pub custom_read_transform: Box<dyn Fn(&EntityRef) -> Option<(DVec3, DQuat)> + Send + Sync>,
+    /// Function for applying a delta to an entity's transform.
+    pub custom_apply_delta: Box<dyn Fn(&mut EntityMut, DVec3, DQuat) + Send + Sync>,
+}
 impl Default for EditorCam {
     fn default() -> Self {
         EditorCam {
@@ -315,28 +325,71 @@ impl EditorCam {
 
     /// Called once every frame to compute motions and update the transforms of all [`EditorCam`]s
     pub fn update_camera_positions(
-        mut cameras: Query<(&mut EditorCam, &Camera, Mut<Transform>, Mut<Projection>)>,
+        mut camera_set: ParamSet<(
+            Query<EntityRef, With<EditorCam>>,
+            Query<(&mut EditorCam, &Camera, Mut<Projection>)>,
+            Query<EntityMut, With<EditorCam>>,
+        )>,
+        read_write: Option<Res<CustomReadWrite>>,
         mut event: MessageWriter<RequestRedraw>,
         time: Res<Time>,
     ) {
-        for (mut camera_controller, camera, transform, projection) in cameras.iter_mut() {
-            let dt = time.delta();
-            camera_controller
-                .update_transform_and_projection(camera, transform, projection, &mut event, dt);
-        }
+        camera_set
+            .p0()
+            .iter()
+            .filter_map(|entity_ref| {
+                EditorCam::read_transform(&entity_ref, &read_write)
+                    .map(|transform| (entity_ref.id(), transform))
+            })
+            .collect::<Vec<_>>()
+            .iter()
+            .filter_map(|(entity, (original_translation, original_rotation))| {
+                camera_set
+                    .p1()
+                    .get_mut(*entity)
+                    .ok()
+                    .map(|(mut camera_controller, camera, ref mut projection)| {
+                        let dt = time.delta();
+                        camera_controller.update_transform_and_projection(
+                            camera,
+                            original_translation,
+                            original_rotation,
+                            projection,
+                            &mut event,
+                            dt,
+                        )
+                    })
+                    .flatten()
+                    .map(|transform| (entity.clone(), transform))
+            })
+            .collect::<Vec<_>>()
+            .iter()
+            .for_each(|(entity, (delta_translation, delta_rotation))| {
+                if let Ok(mut entity_mut) = camera_set.p2().get_mut(*entity) {
+                    EditorCam::apply_delta(
+                        &mut entity_mut,
+                        delta_translation,
+                        delta_rotation,
+                        &read_write,
+                    );
+                }
+            });
     }
 
     /// Update this [`EditorCam`]'s transform and projection.
     pub fn update_transform_and_projection(
         &mut self,
         camera: &Camera,
-        cam_transform: Mut<Transform>,
+        original_translation: &DVec3,
+        original_rotation: &DQuat,
         mut projection: Mut<Projection>,
         redraw: &mut MessageWriter<RequestRedraw>,
         delta_time: Duration,
-    ) {
+    ) -> Option<(DVec3, DQuat)> {
+        let mut new_translation = *original_translation;
+        let mut new_rotation = *original_rotation;
         let (anchor, orbit, pan, zoom) = match &mut self.current_motion {
-            CurrentMotion::Stationary => return,
+            CurrentMotion::Stationary => return None,
             CurrentMotion::Momentum {
                 ref mut velocity, ..
             } => {
@@ -344,7 +397,7 @@ impl EditorCam {
                 match velocity {
                     Velocity::None => {
                         self.current_motion = CurrentMotion::Stationary;
-                        return;
+                        return None;
                     }
                     Velocity::Orbit { anchor, velocity } => (anchor, *velocity, DVec2::ZERO, 0.0),
                     Velocity::Pan { anchor, velocity } => (anchor, DVec2::ZERO, *velocity, 0.0),
@@ -403,14 +456,14 @@ impl EditorCam {
             Projection::Perspective(perspective) => {
                 let Some(offset) = screen_to_view_space_at_depth(perspective, anchor.z) else {
                     error!("Malformed camera");
-                    return;
+                    return None;
                 };
                 offset
             }
             Projection::Orthographic(ortho) => DVec2::new(-ortho.scale as f64, ortho.scale as f64),
             Projection::Custom(_) => {
                 error_once!("Custom projections are not supported.");
-                return;
+                return None;
             }
         };
 
@@ -472,7 +525,7 @@ impl EditorCam {
             }
             Projection::Custom(_) => {
                 error_once!("Custom projections are not supported.");
-                return;
+                return None;
             }
         };
 
@@ -487,28 +540,42 @@ impl EditorCam {
             *anchor += zoom_translation_view_space;
         }
 
-        // Unwrap the [`Mut`] once so we limit the number of
-        // change detection operations for the rest of the function, now we
-        // know we'll mutate the [`Transform`].
-        let cam_transform: &mut Transform = cam_transform.into_inner();
-
-        cam_transform.translation += (cam_transform.rotation.as_dquat()
-            * (pan_translation_view_space + zoom_translation_view_space))
-            .as_vec3();
+        new_translation +=
+            new_rotation * (pan_translation_view_space + zoom_translation_view_space);
 
         *anchor -= pan_translation_view_space + zoom_translation_view_space;
 
         let orbit = orbit * DVec2::new(-1.0, 1.0);
-        let anchor_world = cam_transform
-            .to_matrix()
-            .as_dmat4()
+        let anchor_world = DMat4::from_rotation_translation(new_rotation, new_translation)
             .transform_point3(*anchor);
         let orbit_dir = orbit.normalize().extend(0.0);
-        let orbit_axis_world = cam_transform
-            .rotation
-            .as_dquat()
+        let orbit_axis_world = new_rotation
             .mul_vec3(orbit_dir.cross(DVec3::NEG_Z).normalize())
             .normalize();
+
+        let rotate_around = |cam_translation: &mut DVec3,
+                             cam_rotation: &mut DQuat,
+                             point: DVec3,
+                             rotation: DQuat| {
+            // Following lines are f64 versions of Transform::rotate_around
+            *cam_translation = point + rotation * (*cam_translation - point);
+            *cam_rotation = (rotation * *cam_rotation).normalize();
+        };
+
+        let look_to = |cam_rotation: &mut DQuat, direction: DVec3, up: DVec3| {
+            // Following lines are f64 versions of Transform::look_to
+            let back = -direction;
+            let right = up
+                .cross(back)
+                .try_normalize()
+                .unwrap_or_else(|| up.any_orthogonal_vector());
+            let up = back.cross(right);
+            *cam_rotation = DQuat::from_mat3(&DMat3::from_cols(right, up, back))
+        };
+
+        let cam_forward = |cam_rotation: DQuat| -> DVec3 { cam_rotation * DVec3::NEG_Z };
+        let cam_left = |cam_rotation: DQuat| -> DVec3 { cam_rotation * DVec3::NEG_X };
+        let cam_up = |cam_rotation: DQuat| -> DVec3 { cam_rotation * DVec3::Y };
 
         let orbit_multiplier = 0.005;
         if orbit.is_finite() && orbit.length() != 0.0 {
@@ -516,9 +583,8 @@ impl EditorCam {
                 OrbitConstraint::Fixed { up, can_pass_tdc } => {
                     let epsilon = 1e-3;
                     let motion_threshold = 1e-5;
-
-                    let angle_to_bdc = cam_transform.forward().angle_between(up) as f64;
-                    let angle_to_tdc = cam_transform.forward().angle_between(-up) as f64;
+                    let angle_to_bdc = cam_forward(new_rotation).angle_between(up);
+                    let angle_to_tdc = cam_forward(new_rotation).angle_between(-up);
                     let pitch_angle = {
                         let desired_rotation = orbit.y * orbit_multiplier;
                         if can_pass_tdc {
@@ -532,40 +598,67 @@ impl EditorCam {
                     let pitch = if pitch_angle.abs() <= motion_threshold {
                         DQuat::IDENTITY
                     } else {
-                        DQuat::from_axis_angle(cam_transform.left().as_dvec3(), pitch_angle)
+                        DQuat::from_axis_angle(cam_left(new_rotation), pitch_angle)
                     };
 
                     let yaw_angle = orbit.x * orbit_multiplier;
                     let yaw = if yaw_angle.abs() <= motion_threshold {
                         DQuat::IDENTITY
                     } else {
-                        DQuat::from_axis_angle(up.as_dvec3(), yaw_angle)
+                        DQuat::from_axis_angle(up, yaw_angle)
                     };
 
                     match [pitch == DQuat::IDENTITY, yaw == DQuat::IDENTITY] {
                         [true, true] => (),
-                        [true, false] => rotate_around(cam_transform, anchor_world, yaw),
-                        [false, true] => rotate_around(cam_transform, anchor_world, pitch),
-                        [false, false] => rotate_around(cam_transform, anchor_world, yaw * pitch),
+                        [true, false] => rotate_around(
+                            &mut new_translation,
+                            &mut new_rotation,
+                            anchor_world,
+                            yaw,
+                        ),
+                        [false, true] => rotate_around(
+                            &mut new_translation,
+                            &mut new_rotation,
+                            anchor_world,
+                            pitch,
+                        ),
+                        [false, false] => rotate_around(
+                            &mut new_translation,
+                            &mut new_rotation,
+                            anchor_world,
+                            yaw * pitch,
+                        ),
                     };
-
-                    let how_upright = cam_transform.up().angle_between(up).abs();
+                    let how_upright = cam_up(new_rotation).angle_between(up).abs() as f32;
                     // Orient the camera so up always points up (roll).
+                    let forward = cam_forward(new_rotation);
                     if how_upright > epsilon && how_upright < FRAC_PI_2 - epsilon {
-                        cam_transform.look_to(cam_transform.forward(), up);
+                        look_to(&mut new_rotation, forward, up);
                     } else if how_upright > FRAC_PI_2 + epsilon && how_upright < PI - epsilon {
-                        cam_transform.look_to(cam_transform.forward(), -up);
+                        look_to(&mut new_rotation, forward, -up);
                     }
                 }
                 OrbitConstraint::Free => {
                     let rotation =
                         DQuat::from_axis_angle(orbit_axis_world, orbit.length() * orbit_multiplier);
-                    rotate_around(cam_transform, anchor_world, rotation);
+                    rotate_around(
+                        &mut new_translation,
+                        &mut new_rotation,
+                        anchor_world,
+                        rotation,
+                    );
                 }
             }
         }
 
         self.last_anchor_depth = anchor.z;
+        let (_, delta_rotation, delta_translation) = {
+            let original =
+                DAffine3::from_rotation_translation(*original_rotation, *original_translation);
+            let new = DAffine3::from_rotation_translation(new_rotation, new_translation);
+            (original.inverse() * new).to_scale_rotation_translation()
+        };
+        Some((delta_translation, delta_rotation))
     }
 
     /// Compute the world space size of a pixel at the anchor.
@@ -585,6 +678,77 @@ impl EditorCam {
     pub fn last_anchor_depth(&self) -> f64 {
         -self.last_anchor_depth.abs()
     }
+
+    /// Applies a difference transform onto an entity, using a custom function if it is available via
+    /// ['CustomReadWrite'], or using a default if there isn't one available.
+    pub fn apply_delta(
+        entity: &mut EntityMut,
+        delta_translation: &DVec3,
+        delta_rotation: &DQuat,
+        read_write: &Option<Res<CustomReadWrite>>,
+    ) {
+        if let Some(ref read_write) = read_write {
+            let CustomReadWrite {
+                custom_apply_delta, ..
+            } = &**read_write;
+            custom_apply_delta(entity, *delta_translation, *delta_rotation);
+        } else {
+            Self::default_apply_delta(entity, *delta_translation, *delta_rotation);
+        }
+    }
+
+    /// Retrieves an entity's tranform information, using a custom function if it is available via
+    /// ['CustomReadWrite'], or using a default if there isn't one available.
+    pub fn read_transform(
+        entity: &EntityRef,
+        read_write: &Option<Res<CustomReadWrite>>,
+    ) -> Option<(DVec3, DQuat)> {
+        if let Some(ref read_write) = read_write {
+            let CustomReadWrite {
+                custom_read_transform: read_transform,
+                ..
+            } = &**read_write;
+            read_transform(entity)
+        } else {
+            Self::default_read_transform(entity)
+        }
+    }
+    /// Default fallback for applying transform deltas onto the [`EditorCam`]'s entity.
+    /// Uses Bevy's base ['Transform'] type.
+    fn default_apply_delta(
+        entity: &mut EntityMut,
+        delta_translation: DVec3,
+        delta_rotation: DQuat,
+    ) {
+        let Some(mut cam_transform) = entity.get_mut::<Transform>() else {
+            error!("Unable to retrieve Transform from EditorCam entity.");
+            return;
+        };
+        let delta_transform = Transform::from_translation(delta_translation.as_vec3())
+            .with_rotation(delta_rotation.as_quat());
+        *cam_transform = cam_transform.mul_transform(delta_transform);
+    }
+    /// Default fallback for reading transform information from the [`EditorCam`]'s entity.
+    /// Uses Bevy's base ['Transform'] type.
+    fn default_read_transform(entity: &EntityRef) -> Option<(DVec3, DQuat)> {
+        let Some(cam_transform) = entity.get::<Transform>() else {
+            error!("Unable to retrieve Transform from EditorCam entity.");
+            return None;
+        };
+        Some((
+            cam_transform.translation.as_dvec3(),
+            cam_transform.rotation.as_dquat(),
+        ))
+    }
+}
+
+/// A 64-bit version of Transform::rotate_around
+pub fn rotate_around(transform: &mut Transform, point: DVec3, rotation: DQuat) {
+    transform.translation =
+        (point + rotation * (transform.translation.as_dvec3() - point)).as_vec3();
+    transform.rotation = (rotation * transform.rotation.as_dquat())
+        .as_quat()
+        .normalize();
 }
 
 /// A 64-bit version of Transform::rotate_around
@@ -602,7 +766,7 @@ pub enum OrbitConstraint {
     /// The camera's up direction is fixed.
     Fixed {
         /// The camera's up direction must always be parallel with this unit vector.
-        up: Vec3,
+        up: DVec3,
         /// Should the camera be allowed to pass over top dead center (TDC), making the camera
         /// upside down compared to the up direction?
         can_pass_tdc: bool,
@@ -614,7 +778,7 @@ pub enum OrbitConstraint {
 impl Default for OrbitConstraint {
     fn default() -> Self {
         Self::Fixed {
-            up: Vec3::Y,
+            up: DVec3::Y,
             can_pass_tdc: false,
         }
     }

--- a/src/controller/component.rs
+++ b/src/controller/component.rs
@@ -13,6 +13,8 @@ use bevy_platform::time::Instant;
 use bevy_reflect::prelude::*;
 use bevy_time::prelude::*;
 use bevy_transform::prelude::*;
+
+use super::transform_adapter::TransformAdapter;
 use bevy_window::RequestRedraw;
 
 use super::{
@@ -80,16 +82,6 @@ pub struct EditorCam {
     pub current_motion: CurrentMotion,
 }
 
-/// Optional resource that holds a function for how ['EditorCam'] applies its transform changes.
-/// The intended usage is for situations where a different transform system than Bevy's ['Transform'] component is being used
-/// When this resource is not present, the behavior falls back to a default that uses Bevy's ['Transform'].
-#[derive(Resource)]
-pub struct CustomReadWrite {
-    /// Function for reading transform info from an entity.
-    pub custom_read_transform: Box<dyn Fn(&EntityRef) -> Option<(DVec3, DQuat)> + Send + Sync>,
-    /// Function for applying a delta to an entity's transform.
-    pub custom_apply_delta: Box<dyn Fn(&mut EntityMut, DVec3, DQuat) + Send + Sync>,
-}
 impl Default for EditorCam {
     fn default() -> Self {
         EditorCam {
@@ -330,7 +322,7 @@ impl EditorCam {
             Query<(&mut EditorCam, &Camera, Mut<Projection>)>,
             Query<EntityMut, With<EditorCam>>,
         )>,
-        read_write: Option<Res<CustomReadWrite>>,
+        transform_adapter: Res<TransformAdapter>,
         mut event: MessageWriter<RequestRedraw>,
         time: Res<Time>,
     ) {
@@ -338,7 +330,8 @@ impl EditorCam {
             .p0()
             .iter()
             .filter_map(|entity_ref| {
-                EditorCam::read_transform(&entity_ref, &read_write)
+                transform_adapter
+                    .read(&entity_ref)
                     .map(|transform| (entity_ref.id(), transform))
             })
             .collect::<Vec<_>>()
@@ -366,11 +359,10 @@ impl EditorCam {
             .iter()
             .for_each(|(entity, (delta_translation, delta_rotation))| {
                 if let Ok(mut entity_mut) = camera_set.p2().get_mut(*entity) {
-                    EditorCam::apply_delta(
+                    transform_adapter.apply_delta(
                         &mut entity_mut,
-                        delta_translation,
-                        delta_rotation,
-                        &read_write,
+                        *delta_translation,
+                        *delta_rotation,
                     );
                 }
             });
@@ -608,9 +600,9 @@ impl EditorCam {
                     // Orient the camera so up always points up (roll).
                     let forward = cam_forward(new_rotation);
                     if how_upright > epsilon && how_upright < FRAC_PI_2 - epsilon {
-                        look_to(&mut new_rotation, forward, up);
+                        new_rotation = look_to(forward, up);
                     } else if how_upright > FRAC_PI_2 + epsilon && how_upright < PI - epsilon {
-                        look_to(&mut new_rotation, forward, -up);
+                        new_rotation = look_to(forward, -up);
                     }
                 }
                 OrbitConstraint::Free => {
@@ -652,68 +644,6 @@ impl EditorCam {
     pub fn last_anchor_depth(&self) -> f64 {
         -self.last_anchor_depth.abs()
     }
-
-    /// Applies a difference transform onto an entity, using a custom function if it is available via
-    /// ['CustomReadWrite'], or using a default if there isn't one available.
-    pub fn apply_delta(
-        entity: &mut EntityMut,
-        delta_translation: &DVec3,
-        delta_rotation: &DQuat,
-        read_write: &Option<Res<CustomReadWrite>>,
-    ) {
-        if let Some(ref read_write) = read_write {
-            let CustomReadWrite {
-                custom_apply_delta, ..
-            } = &**read_write;
-            custom_apply_delta(entity, *delta_translation, *delta_rotation);
-        } else {
-            Self::default_apply_delta(entity, *delta_translation, *delta_rotation);
-        }
-    }
-
-    /// Retrieves an entity's tranform information, using a custom function if it is available via
-    /// ['CustomReadWrite'], or using a default if there isn't one available.
-    pub fn read_transform(
-        entity: &EntityRef,
-        read_write: &Option<Res<CustomReadWrite>>,
-    ) -> Option<(DVec3, DQuat)> {
-        if let Some(ref read_write) = read_write {
-            let CustomReadWrite {
-                custom_read_transform: read_transform,
-                ..
-            } = &**read_write;
-            read_transform(entity)
-        } else {
-            Self::default_read_transform(entity)
-        }
-    }
-    /// Default fallback for applying transform deltas onto the [`EditorCam`]'s entity.
-    /// Uses Bevy's base ['Transform'] type.
-    fn default_apply_delta(
-        entity: &mut EntityMut,
-        delta_translation: DVec3,
-        delta_rotation: DQuat,
-    ) {
-        let Some(mut cam_transform) = entity.get_mut::<Transform>() else {
-            error!("Unable to retrieve Transform from EditorCam entity.");
-            return;
-        };
-        let delta_transform = Transform::from_translation(delta_translation.as_vec3())
-            .with_rotation(delta_rotation.as_quat());
-        *cam_transform = cam_transform.mul_transform(delta_transform);
-    }
-    /// Default fallback for reading transform information from the [`EditorCam`]'s entity.
-    /// Uses Bevy's base ['Transform'] type.
-    fn default_read_transform(entity: &EntityRef) -> Option<(DVec3, DQuat)> {
-        let Some(cam_transform) = entity.get::<Transform>() else {
-            error!("Unable to retrieve Transform from EditorCam entity.");
-            return None;
-        };
-        Some((
-            cam_transform.translation.as_dvec3(),
-            cam_transform.rotation.as_dquat(),
-        ))
-    }
 }
 
 /// A 64-bit version of Transform::rotate_around
@@ -722,15 +652,16 @@ pub fn rotate_around(transform: (&mut DVec3, &mut DQuat), point: DVec3, rotation
     *transform.1 = (rotation * *transform.1).normalize();
 }
 
-/// A 64-bit version of Transform::look_to
-pub fn look_to(cam_rotation: &mut DQuat, direction: DVec3, up: DVec3) {
+/// A 64-bit version of Transform::look_to. Returns the rotation quaternion for the given
+/// facing direction and up vector.
+pub fn look_to(direction: DVec3, up: DVec3) -> DQuat {
     let back = -direction;
     let right = up
         .cross(back)
         .try_normalize()
         .unwrap_or_else(|| up.any_orthogonal_vector());
     let up = back.cross(right);
-    *cam_rotation = DQuat::from_mat3(&DMat3::from_cols(right, up, back))
+    DQuat::from_mat3(&DMat3::from_cols(right, up, back))
 }
 
 /// Helper method for getting a local forward vector

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -33,6 +33,6 @@ impl Plugin for MinimalEditorCamPlugin {
                     .chain()
                     .after(bevy_picking::PickingSystems::Last)
                     .in_set(crate::SyncCameraPosition),
-        );
+            );
     }
 }

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -9,6 +9,7 @@ pub mod momentum;
 pub mod motion;
 pub mod projections;
 pub mod smoothing;
+pub mod transform_adapter;
 pub mod zoom;
 
 /// Adds [`bevy_editor_cam`](crate) functionality without an input plugin or any extensions. This
@@ -18,19 +19,20 @@ pub struct MinimalEditorCamPlugin;
 
 impl Plugin for MinimalEditorCamPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(
-            PreUpdate,
-            (
-                crate::controller::component::EditorCam::update_camera_positions,
-                crate::controller::projections::update_orthographic,
-                // Technically `update_perspective` does not alter the camera
-                // position, but the other two systems above do, so I'm putting
-                // them all in the SyncCameraPosition group.
-                crate::controller::projections::update_perspective,
-            )
-                .chain()
-                .after(bevy_picking::PickingSystems::Last)
-                .in_set(crate::SyncCameraPosition),
+        app.init_resource::<transform_adapter::TransformAdapter>()
+            .add_systems(
+                PreUpdate,
+                (
+                    crate::controller::component::EditorCam::update_camera_positions,
+                    crate::controller::projections::update_orthographic,
+                    // Technically `update_perspective` does not alter the camera
+                    // position, but the other two systems above do, so I'm putting
+                    // them all in the SyncCameraPosition group.
+                    crate::controller::projections::update_perspective,
+                )
+                    .chain()
+                    .after(bevy_picking::PickingSystems::Last)
+                    .in_set(crate::SyncCameraPosition),
         );
     }
 }

--- a/src/controller/projections.rs
+++ b/src/controller/projections.rs
@@ -113,7 +113,7 @@ pub fn update_orthographic(
                 let cam_forward = DVec3::NEG_Z;
                 let movement = cam_forward * forward_amount as f64;
 
-                if movement != Vec3::ZERO {
+                if movement != DVec3::ZERO {
                     delta_translation += movement;
                 }
 

--- a/src/controller/projections.rs
+++ b/src/controller/projections.rs
@@ -2,9 +2,8 @@
 
 use bevy_camera::prelude::*;
 use bevy_ecs::prelude::*;
-use bevy_math::Vec3;
+use bevy_math::{DQuat, DVec3};
 use bevy_reflect::prelude::*;
-use bevy_transform::prelude::*;
 
 use crate::prelude::*;
 
@@ -90,31 +89,59 @@ impl Default for OrthographicSettings {
 }
 
 /// Update the ortho camera projection and position based on the [`OrthographicSettings`].
-pub fn update_orthographic(mut cameras: Query<(&mut EditorCam, Mut<Projection>, Mut<Transform>)>) {
-    for (mut editor_cam, mut projection, mut cam_transform) in cameras.iter_mut() {
-        let Projection::Orthographic(ref mut orthographic) = *projection else {
-            continue;
-        };
+pub fn update_orthographic(
+    mut camera_set: ParamSet<(
+        Query<(Entity, &mut EditorCam, Mut<Projection>)>,
+        Query<EntityMut, With<EditorCam>>,
+    )>,
+    read_write: Option<Res<CustomReadWrite>>,
+) {
+    camera_set
+        .p0()
+        .iter_mut()
+        .filter_map(|(entity, mut editor_cam, mut projection)| {
+            if let Projection::Orthographic(ref mut orthographic) = *projection {
+                let mut delta_translation = DVec3::ZERO;
+                let anchor_dist = editor_cam.last_anchor_depth().abs() as f32;
+                let target_dist = (editor_cam.orthographic.scale_to_near_clip * orthographic.scale)
+                    .clamp(
+                        editor_cam.orthographic.near_clip_limits.start,
+                        editor_cam.orthographic.near_clip_limits.end,
+                    );
 
-        let anchor_dist = editor_cam.last_anchor_depth().abs() as f32;
-        let target_dist = (editor_cam.orthographic.scale_to_near_clip * orthographic.scale).clamp(
-            editor_cam.orthographic.near_clip_limits.start,
-            editor_cam.orthographic.near_clip_limits.end,
-        );
+                let forward_amount = anchor_dist - target_dist;
+                let cam_forward = DVec3::NEG_Z;
+                let movement = cam_forward * forward_amount as f64;
 
-        let forward_amount = anchor_dist - target_dist;
-        let movement = cam_transform.forward() * forward_amount;
+                if movement != Vec3::ZERO {
+                    delta_translation += movement;
+                }
 
-        if movement != Vec3::ZERO {
-            cam_transform.translation += movement;
-        }
+                editor_cam.last_anchor_depth += forward_amount as f64;
+                if let CurrentMotion::UserControlled { ref mut anchor, .. } =
+                    editor_cam.current_motion
+                {
+                    anchor.z += forward_amount as f64;
+                }
 
-        editor_cam.last_anchor_depth += forward_amount as f64;
-        if let CurrentMotion::UserControlled { ref mut anchor, .. } = editor_cam.current_motion {
-            anchor.z += forward_amount as f64;
-        }
-
-        orthographic.near = 0.0;
-        orthographic.far = anchor_dist * (1.0 + editor_cam.orthographic.far_clip_multiplier);
-    }
+                orthographic.near = 0.0;
+                orthographic.far =
+                    anchor_dist * (1.0 + editor_cam.orthographic.far_clip_multiplier);
+                Some((entity, delta_translation))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>()
+        .iter()
+        .for_each(|(entity, delta_translation)| {
+            if let Ok(mut entity_mut) = camera_set.p1().get_mut(*entity) {
+                EditorCam::apply_delta(
+                    &mut entity_mut,
+                    delta_translation,
+                    &DQuat::IDENTITY,
+                    &read_write,
+                );
+            }
+        });
 }

--- a/src/controller/projections.rs
+++ b/src/controller/projections.rs
@@ -94,7 +94,7 @@ pub fn update_orthographic(
         Query<(Entity, &mut EditorCam, Mut<Projection>)>,
         Query<EntityMut, With<EditorCam>>,
     )>,
-    read_write: Option<Res<CustomReadWrite>>,
+    transform_adapter: Res<TransformAdapter>,
 ) {
     camera_set
         .p0()
@@ -136,12 +136,7 @@ pub fn update_orthographic(
         .iter()
         .for_each(|(entity, delta_translation)| {
             if let Ok(mut entity_mut) = camera_set.p1().get_mut(*entity) {
-                EditorCam::apply_delta(
-                    &mut entity_mut,
-                    delta_translation,
-                    &DQuat::IDENTITY,
-                    &read_write,
-                );
+                transform_adapter.apply_delta(&mut entity_mut, *delta_translation, DQuat::IDENTITY);
             }
         });
 }

--- a/src/controller/transform_adapter.rs
+++ b/src/controller/transform_adapter.rs
@@ -1,0 +1,74 @@
+//! Defines how the camera controller reads and writes transform data.
+//!
+//! By default, [`TransformAdapter`] reads and writes Bevy's built-in [`Transform`] component.
+//! To use a different transform representation (e.g. a 64-bit transform), replace this resource
+//! with custom `read` and `apply_delta` callbacks.
+
+use bevy_ecs::prelude::*;
+use bevy_log::error_once;
+use bevy_math::{DQuat, DVec3};
+use bevy_transform::prelude::*;
+
+/// Resource that defines how the camera controller reads and writes transform data.
+///
+/// By default, this reads and writes Bevy's built-in [`Transform`] component. Replace this
+/// resource to use a different transform component (e.g. a 64-bit transform) via [`Self::new`].
+#[derive(Resource)]
+pub struct TransformAdapter {
+    read_fn: Box<dyn Fn(&EntityRef) -> Option<(DVec3, DQuat)> + Send + Sync>,
+    apply_delta_fn: Box<dyn Fn(&mut EntityMut, DVec3, DQuat) + Send + Sync>,
+}
+
+impl TransformAdapter {
+    /// Create a new `TransformAdapter` with custom read and apply_delta callbacks.
+    pub fn new(
+        read: impl Fn(&EntityRef) -> Option<(DVec3, DQuat)> + Send + Sync + 'static,
+        apply_delta: impl Fn(&mut EntityMut, DVec3, DQuat) + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            read_fn: Box::new(read),
+            apply_delta_fn: Box::new(apply_delta),
+        }
+    }
+
+    /// Read the translation and rotation of an entity.
+    pub fn read(&self, entity: &EntityRef) -> Option<(DVec3, DQuat)> {
+        (self.read_fn)(entity)
+    }
+
+    /// Apply a movement delta to an entity.
+    pub fn apply_delta(
+        &self,
+        entity: &mut EntityMut,
+        delta_translation: DVec3,
+        delta_rotation: DQuat,
+    ) {
+        (self.apply_delta_fn)(entity, delta_translation, delta_rotation)
+    }
+}
+
+impl Default for TransformAdapter {
+    fn default() -> Self {
+        Self::new(
+            |entity| {
+                let Some(cam_transform) = entity.get::<Transform>() else {
+                    error_once!("Unable to retrieve Transform from EditorCam entity.");
+                    return None;
+                };
+                Some((
+                    cam_transform.translation.as_dvec3(),
+                    cam_transform.rotation.as_dquat(),
+                ))
+            },
+            |entity, delta_translation, delta_rotation| {
+                let Some(mut cam_transform) = entity.get_mut::<Transform>() else {
+                    error_once!("Unable to retrieve Transform from EditorCam entity.");
+                    return;
+                };
+                let delta_transform = Transform::from_translation(delta_translation.as_vec3())
+                    .with_rotation(delta_rotation.as_quat());
+                *cam_transform = cam_transform.mul_transform(delta_transform);
+            },
+        )
+    }
+}

--- a/src/extensions/dolly_zoom.rs
+++ b/src/extensions/dolly_zoom.rs
@@ -14,7 +14,7 @@ use bevy_platform::{collections::HashMap, time::Instant};
 use bevy_reflect::prelude::*;
 use bevy_window::RequestRedraw;
 
-use crate::prelude::{motion::CurrentMotion, CustomReadWrite, EditorCam, EnabledMotion};
+use crate::prelude::{motion::CurrentMotion, EditorCam, EnabledMotion, TransformAdapter};
 
 /// See the [module](self) docs.
 pub struct DollyZoomPlugin;
@@ -52,7 +52,7 @@ impl DollyZoomTrigger {
             Query<(&Camera, Mut<Projection>, &mut EditorCam)>,
             Query<EntityMut, With<EditorCam>>,
         )>,
-        read_write: Option<Res<CustomReadWrite>>,
+        transform_adapter: Res<TransformAdapter>,
         mut redraw: MessageWriter<RequestRedraw>,
     ) {
         for event in events.read() {
@@ -136,12 +136,7 @@ impl DollyZoomTrigger {
 
             let mut camera_muts = camera_set.p1();
             let mut camera_mut = camera_muts.get_mut(event.camera).unwrap();
-            EditorCam::apply_delta(
-                &mut camera_mut,
-                &delta_translation,
-                &DQuat::IDENTITY,
-                &read_write,
-            );
+            transform_adapter.apply_delta(&mut camera_mut, delta_translation, DQuat::IDENTITY);
         }
     }
 }
@@ -184,7 +179,7 @@ impl DollyZoom {
             Query<(&Camera, Mut<Projection>, &mut EditorCam)>,
             Query<EntityMut, With<EditorCam>>,
         )>,
-        read_write: Option<Res<CustomReadWrite>>,
+        transform_adapter: Res<TransformAdapter>,
         mut redraw: MessageWriter<RequestRedraw>,
     ) {
         let animation_duration = state.animation_duration;
@@ -259,12 +254,7 @@ impl DollyZoom {
 
             let mut camera_muts = camera_set.p1();
             let mut camera_mut = camera_muts.get_mut(*camera_entity).unwrap();
-            EditorCam::apply_delta(
-                &mut camera_mut,
-                &delta_translation,
-                &DQuat::IDENTITY,
-                &read_write,
-            );
+            transform_adapter.apply_delta(&mut camera_mut, delta_translation, DQuat::IDENTITY);
         }
         state.map.retain(|_, v| !v.complete);
     }

--- a/src/extensions/dolly_zoom.rs
+++ b/src/extensions/dolly_zoom.rs
@@ -9,13 +9,12 @@ use bevy_app::prelude::*;
 use bevy_camera::{prelude::*, ScalingMode};
 use bevy_ecs::prelude::*;
 use bevy_log::error_once;
-use bevy_math::prelude::*;
+use bevy_math::{prelude::*, DQuat, DVec3};
 use bevy_platform::{collections::HashMap, time::Instant};
 use bevy_reflect::prelude::*;
-use bevy_transform::prelude::*;
 use bevy_window::RequestRedraw;
 
-use crate::prelude::{motion::CurrentMotion, EditorCam, EnabledMotion};
+use crate::prelude::{motion::CurrentMotion, CustomReadWrite, EditorCam, EnabledMotion};
 
 /// See the [module](self) docs.
 pub struct DollyZoomPlugin;
@@ -49,15 +48,19 @@ impl DollyZoomTrigger {
     fn receive(
         mut events: MessageReader<Self>,
         mut state: ResMut<DollyZoom>,
-        mut cameras: Query<(&Camera, Mut<Projection>, Mut<EditorCam>, Mut<Transform>)>,
+        mut camera_set: ParamSet<(
+            Query<(&Camera, Mut<Projection>, &mut EditorCam)>,
+            Query<EntityMut, With<EditorCam>>,
+        )>,
+        read_write: Option<Res<CustomReadWrite>>,
         mut redraw: MessageWriter<RequestRedraw>,
     ) {
         for event in events.read() {
-            let Ok((camera, mut proj, mut controller, mut transform)) =
-                cameras.get_mut(event.camera)
-            else {
+            let mut cameras = camera_set.p0();
+            let Ok((camera, mut proj, mut controller)) = cameras.get_mut(event.camera) else {
                 continue;
             };
+            let mut delta_translation = DVec3::ZERO;
             redraw.write(RequestRedraw);
             let (fov_start, triangle_base) = match &*proj {
                 Projection::Perspective(perspective) => {
@@ -84,9 +87,10 @@ impl DollyZoomTrigger {
                     let base = ortho.scale as f64 / ortho_tri_base_to_scale_factor(camera, ortho);
                     let new_anchor_dist = base / (ZERO_FOV / 2.0).tan();
                     let forward_dist = controller.last_anchor_depth.abs() - new_anchor_dist;
-                    let next_translation = transform.forward().as_dvec3() * forward_dist;
+                    let cam_forward = DVec3::NEG_Z;
+                    let next_translation = cam_forward * forward_dist;
 
-                    transform.translation += next_translation.as_vec3();
+                    delta_translation += next_translation;
                     controller.last_anchor_depth += forward_dist;
 
                     (ZERO_FOV as f32, base)
@@ -129,6 +133,15 @@ impl DollyZoomTrigger {
                 orbit: false,
                 zoom: false,
             };
+
+            let mut camera_muts = camera_set.p1();
+            let mut camera_mut = camera_muts.get_mut(event.camera).unwrap();
+            EditorCam::apply_delta(
+                &mut camera_mut,
+                &delta_translation,
+                &DQuat::IDENTITY,
+                &read_write,
+            );
         }
     }
 }
@@ -167,13 +180,17 @@ impl Default for DollyZoom {
 impl DollyZoom {
     fn update(
         mut state: ResMut<Self>,
-        mut cameras: Query<(&Camera, Mut<Projection>, Mut<Transform>, &mut EditorCam)>,
+        mut camera_set: ParamSet<(
+            Query<(&Camera, Mut<Projection>, &mut EditorCam)>,
+            Query<EntityMut, With<EditorCam>>,
+        )>,
+        read_write: Option<Res<CustomReadWrite>>,
         mut redraw: MessageWriter<RequestRedraw>,
     ) {
         let animation_duration = state.animation_duration;
         let animation_curve = state.animation_curve;
         for (
-            camera,
+            camera_entity,
             ZoomEntry {
                 perspective_start,
                 proj_end,
@@ -184,19 +201,20 @@ impl DollyZoom {
             },
         ) in state.map.iter_mut()
         {
-            let Ok((camera, mut projection, mut transform, mut controller)) =
-                cameras.get_mut(*camera)
+            let mut cameras = camera_set.p0();
+            let Ok((camera, mut projection, mut controller)) = cameras.get_mut(*camera_entity)
             else {
                 *complete = true;
                 continue;
             };
-
             let Projection::Perspective(last_perspective) = projection.clone() else {
                 *projection = proj_end.clone();
                 controller.enabled_motion = initial_enabled.clone();
                 *complete = true;
                 continue;
             };
+
+            let mut delta_translation = DVec3::ZERO;
 
             let last_fov = last_perspective.fov as f64;
             let fov_start = perspective_start.fov as f64;
@@ -216,9 +234,10 @@ impl DollyZoom {
             let last_dist = *triangle_base / (last_fov / 2.0).tan();
             let next_dist = *triangle_base / (next_fov / 2.0).tan();
             let forward_dist = last_dist - next_dist;
-            let next_translation = transform.forward().as_dvec3() * forward_dist;
+            let cam_forward = DVec3::NEG_Z;
+            let next_translation = cam_forward * forward_dist;
 
-            transform.translation += next_translation.as_vec3();
+            delta_translation += next_translation;
             controller.last_anchor_depth += forward_dist;
 
             if progress < 1.0 {
@@ -237,6 +256,15 @@ impl DollyZoom {
                 *complete = true;
             }
             redraw.write(RequestRedraw);
+
+            let mut camera_muts = camera_set.p1();
+            let mut camera_mut = camera_muts.get_mut(*camera_entity).unwrap();
+            EditorCam::apply_delta(
+                &mut camera_mut,
+                &delta_translation,
+                &DQuat::IDENTITY,
+                &read_write,
+            );
         }
         state.map.retain(|_, v| !v.complete);
     }

--- a/src/extensions/look_to.rs
+++ b/src/extensions/look_to.rs
@@ -1,14 +1,13 @@
 //! A `bevy_editor_cam` extension that adds the ability to smoothly rotate the camera about its
 //! anchor point until it is looking in the specified direction.
 
-use std::{f32::consts::PI, time::Duration};
+use std::{f64::consts::PI, time::Duration};
 
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
-use bevy_math::{prelude::*, DVec3};
+use bevy_math::{prelude::*, DAffine3, DMat3, DQuat, DVec3};
 use bevy_platform::{collections::HashMap, time::Instant};
 use bevy_reflect::prelude::*;
-use bevy_transform::prelude::*;
 use bevy_window::RequestRedraw;
 
 use crate::prelude::*;
@@ -34,9 +33,9 @@ impl Plugin for LookToPlugin {
 #[derive(Debug, Message)]
 pub struct LookToTrigger {
     /// The new direction to face.
-    pub target_facing_direction: Dir3,
+    pub target_facing_direction: DVec3,
     /// The camera's "up" direction when finished moving.
-    pub target_up_direction: Dir3,
+    pub target_up_direction: DVec3,
     /// The camera to update.
     pub camera: Entity,
 }
@@ -49,12 +48,12 @@ impl LookToTrigger {
     /// the facing direction is parallel to the fixed up direction, the up direction will be
     /// automatically selected by choosing the axis that results in the least amount of rotation.
     pub fn auto_snap_up_direction(
-        facing: Dir3,
+        facing: DVec3,
         cam_entity: Entity,
-        cam_transform: &Transform,
+        cam_rotation: &DQuat,
         cam_editor: &EditorCam,
     ) -> Self {
-        const EPSILON: f32 = 0.01;
+        const EPSILON: f64 = 0.01;
         let constraint = match cam_editor.orbit_constraint {
             OrbitConstraint::Fixed { up, .. } => Some(up),
             OrbitConstraint::Free => None,
@@ -64,28 +63,39 @@ impl LookToTrigger {
             angle > EPSILON && angle < PI - EPSILON
         });
 
+        let looking_to = |direction: DVec3, up: DVec3| -> DQuat {
+            // Following lines are f64 versions of Transform::look_to
+            let back = -direction;
+            let right = up
+                .cross(back)
+                .try_normalize()
+                .unwrap_or_else(|| up.any_orthogonal_vector());
+            let up = back.cross(right);
+            DQuat::from_mat3(&DMat3::from_cols(right, up, back))
+        };
+
         let up = constraint.unwrap_or_else(|| {
-            let current = cam_transform.rotation;
+            let current = cam_rotation;
             let options = [
-                Vec3::X,
-                Vec3::NEG_X,
-                Vec3::Y,
-                Vec3::NEG_Y,
-                Vec3::Z,
-                Vec3::NEG_Z,
+                DVec3::X,
+                DVec3::NEG_X,
+                DVec3::Y,
+                DVec3::NEG_Y,
+                DVec3::Z,
+                DVec3::NEG_Z,
             ];
             *options
                 .iter()
-                .map(|d| (d, Transform::default().looking_to(*facing, *d).rotation))
-                .map(|(d, rot)| (d, rot.angle_between(current).abs()))
+                .map(|d| (d, looking_to(facing, *d)))
+                .map(|(d, rot)| (d, rot.angle_between(*current).abs()))
                 .reduce(|acc, this| if this.1 < acc.1 { this } else { acc })
                 .map(|nearest| nearest.0)
-                .unwrap_or(&Vec3::Y)
+                .unwrap_or(&DVec3::Y)
         });
 
         LookToTrigger {
             target_facing_direction: facing,
-            target_up_direction: Dir3::new_unchecked(up.normalize()),
+            target_up_direction: up.normalize(),
             camera: cam_entity,
         }
     }
@@ -95,30 +105,41 @@ impl LookToTrigger {
     fn receive(
         mut events: MessageReader<Self>,
         mut state: ResMut<LookTo>,
-        mut cameras: Query<(&mut EditorCam, &Transform)>,
+        mut camera_set: ParamSet<(Query<&mut EditorCam>, Query<EntityRef, With<EditorCam>>)>,
         mut redraw: MessageWriter<RequestRedraw>,
+        read_write: Option<Res<CustomReadWrite>>,
     ) {
         for event in events.read() {
-            let Ok((mut controller, transform)) = cameras.get_mut(event.camera) else {
+            let camera_refs = camera_set.p1();
+            let Ok(camera_ref) = camera_refs.get(event.camera) else {
+                continue;
+            };
+            let Some((_, camera_rotation)) = EditorCam::read_transform(&camera_ref, &read_write)
+            else {
+                continue;
+            };
+            let mut cameras = camera_set.p0();
+            let Ok(mut controller) = cameras.get_mut(event.camera) else {
                 continue;
             };
             redraw.write(RequestRedraw);
-
+            let camera_forward = camera_rotation * DVec3::NEG_Z;
+            let camera_up = camera_rotation * DVec3::Y;
             state
                 .map
                 .entry(event.camera)
                 .and_modify(|e| {
                     e.start = Instant::now();
-                    e.initial_facing_direction = transform.forward();
-                    e.initial_up_direction = transform.up();
+                    e.initial_facing_direction = camera_forward;
+                    e.initial_up_direction = camera_up;
                     e.target_facing_direction = event.target_facing_direction;
                     e.target_up_direction = event.target_up_direction;
                     e.complete = false;
                 })
                 .or_insert(LookToEntry {
                     start: Instant::now(),
-                    initial_facing_direction: transform.forward(),
-                    initial_up_direction: transform.up(),
+                    initial_facing_direction: camera_forward,
+                    initial_up_direction: camera_up,
                     target_facing_direction: event.target_facing_direction,
                     target_up_direction: event.target_up_direction,
                     complete: false,
@@ -132,10 +153,10 @@ impl LookToTrigger {
 
 struct LookToEntry {
     start: Instant,
-    initial_facing_direction: Dir3,
-    initial_up_direction: Dir3,
-    target_facing_direction: Dir3,
-    target_up_direction: Dir3,
+    initial_facing_direction: DVec3,
+    initial_up_direction: DVec3,
+    target_facing_direction: DVec3,
+    target_up_direction: DVec3,
     complete: bool,
 }
 
@@ -164,8 +185,13 @@ impl Default for LookTo {
 impl LookTo {
     fn update(
         mut state: ResMut<Self>,
-        mut cameras: Query<(Mut<Transform>, &EditorCam)>,
+        mut camera_set: ParamSet<(
+            Query<&mut EditorCam>,
+            Query<EntityRef, With<EditorCam>>,
+            Query<EntityMut, With<EditorCam>>,
+        )>,
         mut redraw: MessageWriter<RequestRedraw>,
+        read_write: Option<Res<CustomReadWrite>>,
     ) {
         let animation_duration = state.animation_duration;
         let animation_curve = state.animation_curve;
@@ -181,13 +207,32 @@ impl LookTo {
             },
         ) in state.map.iter_mut()
         {
-            let Ok((mut transform, controller)) = cameras.get_mut(*camera) else {
+            let camera_refs = camera_set.p1();
+            let Ok(camera_ref) = camera_refs.get(*camera) else {
+                continue;
+            };
+            let Some((mut camera_translation, mut camera_rotation)) =
+                EditorCam::read_transform(&camera_ref, &read_write)
+            else {
+                continue;
+            };
+            let mut cameras = camera_set.p0();
+            let Ok(controller) = cameras.get_mut(*camera) else {
                 *complete = true;
                 continue;
             };
             let progress_t =
                 (start.elapsed().as_secs_f32() / animation_duration.as_secs_f32()).clamp(0.0, 1.0);
             let progress = animation_curve.ease(progress_t);
+
+            let rotate_around = |trans_translation: &mut DVec3,
+                                 trans_rotation: &mut DQuat,
+                                 point: DVec3,
+                                 rotation: DQuat| {
+                // Following lines are f64 versions of Transform::rotate_around
+                *trans_translation = point + rotation * (*trans_translation - point);
+                *trans_rotation = (rotation * *trans_rotation).normalize();
+            };
 
             let anchor_view_space = controller.anchor_view_space().unwrap_or(DVec3::new(
                 0.0,
@@ -196,23 +241,51 @@ impl LookTo {
             ));
 
             let anchor_world = {
-                let (r, t) = (transform.rotation, transform.translation);
-                r.as_dquat() * anchor_view_space + t.as_dvec3()
+                let (r, t) = (camera_rotation, camera_translation);
+                r * anchor_view_space + t
             };
 
-            let rot_init = Transform::default()
-                .looking_to(**initial_facing_direction, **initial_up_direction)
-                .rotation;
-            let rot_target = Transform::default()
-                .looking_to(**target_facing_direction, **target_up_direction)
-                .rotation;
+            let looking_to = |direction: DVec3, up: DVec3| -> DQuat {
+                // Following lines are f64 versions of Transform::look_to
+                let back = -direction;
+                let right = up
+                    .cross(back)
+                    .try_normalize()
+                    .unwrap_or_else(|| up.any_orthogonal_vector());
+                let up = back.cross(right);
+                DQuat::from_mat3(&DMat3::from_cols(right, up, back))
+            };
 
-            let rot_next = rot_init.slerp(rot_target, progress);
-            let rot_last = transform.rotation;
+            let rot_init = looking_to(*initial_facing_direction, *initial_up_direction);
+            let rot_target = looking_to(*target_facing_direction, *target_up_direction);
+
+            let rot_next = rot_init.slerp(rot_target, progress as f64);
+            let rot_last = camera_rotation;
             let rot_delta = rot_next * rot_last.inverse();
 
-            rotate_around(&mut transform, anchor_world, rot_delta.as_dquat());
+            let original_translation = camera_translation;
+            let original_rotation = camera_rotation;
+            rotate_around(
+                &mut camera_translation,
+                &mut camera_rotation,
+                anchor_world,
+                rot_delta,
+            );
+            let (_, delta_rotation, delta_translation) = {
+                let original =
+                    DAffine3::from_rotation_translation(original_rotation, original_translation);
+                let new = DAffine3::from_rotation_translation(camera_rotation, camera_translation);
+                (original.inverse() * new).to_scale_rotation_translation()
+            };
 
+            let mut camera_muts = camera_set.p2();
+            let mut camera_mut = camera_muts.get_mut(*camera).unwrap();
+            EditorCam::apply_delta(
+                &mut camera_mut,
+                &delta_translation,
+                &delta_rotation,
+                &read_write,
+            );
             if progress_t >= 1.0 {
                 *complete = true;
             }

--- a/src/extensions/look_to.rs
+++ b/src/extensions/look_to.rs
@@ -5,7 +5,7 @@ use std::{f64::consts::PI, time::Duration};
 
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
-use bevy_math::{prelude::*, DAffine3, DMat3, DQuat, DVec3};
+use bevy_math::{prelude::*, DAffine3, DQuat, DVec3};
 use bevy_platform::{collections::HashMap, time::Instant};
 use bevy_reflect::prelude::*;
 use bevy_window::RequestRedraw;
@@ -63,17 +63,6 @@ impl LookToTrigger {
             angle > EPSILON && angle < PI - EPSILON
         });
 
-        let looking_to = |direction: DVec3, up: DVec3| -> DQuat {
-            // Following lines are f64 versions of Transform::look_to
-            let back = -direction;
-            let right = up
-                .cross(back)
-                .try_normalize()
-                .unwrap_or_else(|| up.any_orthogonal_vector());
-            let up = back.cross(right);
-            DQuat::from_mat3(&DMat3::from_cols(right, up, back))
-        };
-
         let up = constraint.unwrap_or_else(|| {
             let current = cam_rotation;
             let options = [
@@ -86,7 +75,7 @@ impl LookToTrigger {
             ];
             *options
                 .iter()
-                .map(|d| (d, looking_to(facing, *d)))
+                .map(|d| (d, look_to(facing, *d)))
                 .map(|(d, rot)| (d, rot.angle_between(*current).abs()))
                 .reduce(|acc, this| if this.1 < acc.1 { this } else { acc })
                 .map(|nearest| nearest.0)
@@ -107,15 +96,14 @@ impl LookToTrigger {
         mut state: ResMut<LookTo>,
         mut camera_set: ParamSet<(Query<&mut EditorCam>, Query<EntityRef, With<EditorCam>>)>,
         mut redraw: MessageWriter<RequestRedraw>,
-        read_write: Option<Res<CustomReadWrite>>,
+        transform_adapter: Res<TransformAdapter>,
     ) {
         for event in events.read() {
             let camera_refs = camera_set.p1();
             let Ok(camera_ref) = camera_refs.get(event.camera) else {
                 continue;
             };
-            let Some((_, camera_rotation)) = EditorCam::read_transform(&camera_ref, &read_write)
-            else {
+            let Some((_, camera_rotation)) = transform_adapter.read(&camera_ref) else {
                 continue;
             };
             let mut cameras = camera_set.p0();
@@ -191,7 +179,7 @@ impl LookTo {
             Query<EntityMut, With<EditorCam>>,
         )>,
         mut redraw: MessageWriter<RequestRedraw>,
-        read_write: Option<Res<CustomReadWrite>>,
+        transform_adapter: Res<TransformAdapter>,
     ) {
         let animation_duration = state.animation_duration;
         let animation_curve = state.animation_curve;
@@ -212,7 +200,7 @@ impl LookTo {
                 continue;
             };
             let Some((mut camera_translation, mut camera_rotation)) =
-                EditorCam::read_transform(&camera_ref, &read_write)
+                transform_adapter.read(&camera_ref)
             else {
                 continue;
             };
@@ -225,15 +213,6 @@ impl LookTo {
                 (start.elapsed().as_secs_f32() / animation_duration.as_secs_f32()).clamp(0.0, 1.0);
             let progress = animation_curve.ease(progress_t);
 
-            let rotate_around = |trans_translation: &mut DVec3,
-                                 trans_rotation: &mut DQuat,
-                                 point: DVec3,
-                                 rotation: DQuat| {
-                // Following lines are f64 versions of Transform::rotate_around
-                *trans_translation = point + rotation * (*trans_translation - point);
-                *trans_rotation = (rotation * *trans_rotation).normalize();
-            };
-
             let anchor_view_space = controller.anchor_view_space().unwrap_or(DVec3::new(
                 0.0,
                 0.0,
@@ -245,19 +224,8 @@ impl LookTo {
                 r * anchor_view_space + t
             };
 
-            let looking_to = |direction: DVec3, up: DVec3| -> DQuat {
-                // Following lines are f64 versions of Transform::look_to
-                let back = -direction;
-                let right = up
-                    .cross(back)
-                    .try_normalize()
-                    .unwrap_or_else(|| up.any_orthogonal_vector());
-                let up = back.cross(right);
-                DQuat::from_mat3(&DMat3::from_cols(right, up, back))
-            };
-
-            let rot_init = looking_to(*initial_facing_direction, *initial_up_direction);
-            let rot_target = looking_to(*target_facing_direction, *target_up_direction);
+            let rot_init = look_to(*initial_facing_direction, *initial_up_direction);
+            let rot_target = look_to(*target_facing_direction, *target_up_direction);
 
             let rot_next = rot_init.slerp(rot_target, progress as f64);
             let rot_last = camera_rotation;
@@ -266,8 +234,7 @@ impl LookTo {
             let original_translation = camera_translation;
             let original_rotation = camera_rotation;
             rotate_around(
-                &mut camera_translation,
-                &mut camera_rotation,
+                (&mut camera_translation, &mut camera_rotation),
                 anchor_world,
                 rot_delta,
             );
@@ -280,12 +247,7 @@ impl LookTo {
 
             let mut camera_muts = camera_set.p2();
             let mut camera_mut = camera_muts.get_mut(*camera).unwrap();
-            EditorCam::apply_delta(
-                &mut camera_mut,
-                &delta_translation,
-                &delta_rotation,
-                &read_write,
-            );
+            transform_adapter.apply_delta(&mut camera_mut, delta_translation, delta_rotation);
             if progress_t >= 1.0 {
                 *complete = true;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@ pub mod input;
 /// Common imports.
 pub mod prelude {
     pub use crate::{
-        controller::{component::*, *},
+        controller::{component::*, transform_adapter::*, *},
         DefaultEditorCamPlugins,
     };
 }


### PR DESCRIPTION
Mainline version of #63.

Adds support for arbitrary transform components for alternative transform propagation systems.