### PR TITLE
Sync near_clip_plane with near in update_perspective (fixes depth corruption on Bevy 0.18)

### DIFF
--- a/src/controller/projections.rs
+++ b/src/controller/projections.rs
@@ -2,7 +2,7 @@
 
 use bevy_camera::prelude::*;
 use bevy_ecs::prelude::*;
-use bevy_math::{DQuat, DVec3};
+use bevy_math::{DQuat, DVec3, Vec4};
 use bevy_reflect::prelude::*;
 
 use crate::prelude::*;
@@ -51,6 +51,16 @@ pub fn update_perspective(mut cameras: Query<(&EditorCam, Mut<Projection>)>) {
         let multiplier = editor_cam.perspective.near_clip_multiplier;
         perspective.near = (editor_cam.last_anchor_depth.abs() as f32 * multiplier)
             .clamp(limits.start, limits.end);
+        // Keep `near_clip_plane` matched to `near`. `PerspectiveProjection::get_clip_from_view`
+        // applies an oblique near-clip-plane adjustment whenever
+        // `near_clip_plane != vec4(0, 0, -1, -near)`. Because we change `near` every frame, leaving
+        // `near_clip_plane` at its default (which matches the *default* `near`, 0.1) silently turns
+        // on that oblique adjustment, rewriting the projection's z-row and corrupting the depth
+        // buffer for every camera the controller drives. That breaks depth-dependent rendering
+        // (eye-dome lighting, SSAO, etc.) even though geometry positions look correct. Re-matching
+        // the plane keeps the adjustment a no-op. (The controller is incompatible with a genuine
+        // oblique near plane anyway, since it overwrites `near` continuously.)
+        perspective.near_clip_plane = Vec4::new(0.0, 0.0, -1.0, -perspective.near);
     }
 }
 


### PR DESCRIPTION
## Problem

On Bevy 0.18, `PerspectiveProjection::get_clip_from_view` applies an oblique near-clip-plane adjustment (Lengyel) whenever `near_clip_plane != vec4(0, 0, -1, -near)`:

```rust
fn get_clip_from_view(&self) -> Mat4 {
    let mut matrix = Mat4::perspective_infinite_reverse_rh(self.fov, self.aspect_ratio, self.near);
    self.adjust_perspective_matrix_for_clip_plane(&mut matrix); // no-op only if near_clip_plane == vec4(0,0,-1,-near)
    matrix
}
```

`update_perspective` rewrites `perspective.near` every frame (to keep the zoom anchor inside the frustum) but never touches `near_clip_plane`. As soon as the controller moves `near` away from the default `0.1`, the default `near_clip_plane` (`vec4(0,0,-1,-0.1)`) no longer matches it, so the oblique adjustment silently switches on. It rewrites the projection's z-row (`x_axis.z`, `y_axis.z`, `z_axis.z`, `w_axis.z`), which means:

- geometry **positions** still look correct (x/y are unaffected), but
- the **depth-buffer values are wrong**, corrupting every depth-dependent effect on cameras the controller drives — eye-dome lighting, SSAO, etc.

This showed up as broken eye-dome lighting after migrating a renderer from Bevy 0.17 to 0.18 (0.17 had no oblique near-clip-plane feature, so the controller's behavior was fine there).

## Fix

Re-match `near_clip_plane` to `near` right after the controller sets `near`, so the oblique adjustment stays a no-op:

```rust
perspective.near_clip_plane = Vec4::new(0.0, 0.0, -1.0, -perspective.near);
```

The controller is incompatible with an intentional oblique near plane anyway, since it overwrites `near` every frame.

## Verification

Reproduced the depth corruption with a depth-based post-process (eye-dome lighting) on an `EditorCam`, comparing a rendered frame against the Bevy 0.17 baseline: ~7% of pixels differed (concentrated at depth discontinuities/silhouettes). With `near_clip_plane` matched to `near`, the same comparison drops to ~0.3% (the run-to-run noise floor) — i.e. the projection depth matches the pre-0.18 behavior again. Builds against Bevy 0.18.
