### PR TITLE
v0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_editor_cam"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "A camera controller for editors and CAD."
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://github.com/user-attachments/assets/58b270a9-7ae8-4466-9a8f-1fc8f0896590
 
 | bevy | bevy_editor_cam |
 |------|-----------------|
-| 0.18 | 0.8             |
+| 0.18 | 0.8, 0.9        |
 | 0.17 | 0.7             |
 | 0.16 | 0.6             |
 | 0.15 | 0.5             |


### PR DESCRIPTION
Bumps the crate version from 0.8.0 to 0.9.0 to release the transform-adapter work (#64) currently on main.

Breaking changes since 0.8.0:

- `LookToTrigger` public fields `target_facing_direction` and `target_up_direction` changed type from `Dir3` to `DVec3`. Its constructors now take `DVec3` and no longer take a `&Transform` argument.
- `OrbitConstraint::Fixed { up }` changed from `Vec3` to `DVec3`.
- `rotate_around` signature changed from `&mut Transform` to `(&mut DVec3, &mut DQuat)`.
- Controller and extension systems now route transform reads/writes through the new `TransformAdapter` resource.

Additive: new `TransformAdapter` resource and module, plus `look_to`, `cam_forward`, `cam_left`, and `cam_up` helper functions.